### PR TITLE
Remove unnecessary features assignment

### DIFF
--- a/lib/src/growth_book_sdk.dart
+++ b/lib/src/growth_book_sdk.dart
@@ -197,12 +197,6 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
         context: _context,
       ),
     );
-    if (_gbFeatures != null) {
-      _context.features = _gbFeatures!;
-    }
-    if (_savedGroups != null) {
-      _context.savedGroups = _savedGroups!;
-    }
     if (_context.remoteEval) {
       refreshForRemoteEval();
     } else {


### PR DESCRIPTION
This pull request addresses [issue #43](https://github.com/growthbook/growthbook-flutter/issues/43). It removes unnecessary reassignments of features and savedGroups in the refresh method.