### PR TITLE
initializing evaluationContext to enable setting StickyBucketService

### DIFF
--- a/lib/growthbook_sdk_flutter.dart
+++ b/lib/growthbook_sdk_flutter.dart
@@ -11,3 +11,4 @@ export 'src/Model/model.dart';
 export 'src/Network/network.dart';
 export 'src/Utils/utils.dart';
 export 'src/growth_book_sdk.dart';
+export 'src/Model/sticky_assignments_document.dart';

--- a/lib/src/growth_book_sdk.dart
+++ b/lib/src/growth_book_sdk.dart
@@ -14,24 +14,23 @@ typedef VoidCallback = void Function();
 typedef OnInitializationFailure = void Function(GBError? error);
 
 class GBSDKBuilderApp {
-  GBSDKBuilderApp({
-    required this.hostURL,
-    required this.apiKey,
-    this.encryptionKey,
-    required this.growthBookTrackingCallBack,
-    this.attributes = const <String, dynamic>{},
-    this.qaMode = false,
-    this.enable = true,
-    this.forcedVariations = const <String, int>{},
-    this.client,
-    this.gbFeatures = const {},
-    this.onInitializationFailure,
-    this.refreshHandler,
-    this.stickyBucketService,
-    this.backgroundSync = false,
-    this.remoteEval = false,
-    this.url
-  });
+  GBSDKBuilderApp(
+      {required this.hostURL,
+      required this.apiKey,
+      this.encryptionKey,
+      required this.growthBookTrackingCallBack,
+      this.attributes = const <String, dynamic>{},
+      this.qaMode = false,
+      this.enable = true,
+      this.forcedVariations = const <String, int>{},
+      this.client,
+      this.gbFeatures = const {},
+      this.onInitializationFailure,
+      this.refreshHandler,
+      this.stickyBucketService,
+      this.backgroundSync = false,
+      this.remoteEval = false,
+      this.url});
 
   final String apiKey;
   final String? encryptionKey;
@@ -52,24 +51,22 @@ class GBSDKBuilderApp {
   StickyBucketService? stickyBucketService;
   GBFeatureUsageCallback? featureUsageCallback;
 
-
   Future<GrowthBookSDK> initialize() async {
     final gbContext = GBContext(
-      apiKey: apiKey,
-      encryptionKey: encryptionKey,
-      hostURL: hostURL,
-      enabled: enable,
-      qaMode: qaMode,
-      attributes: attributes,
-      forcedVariation: forcedVariations,
-      trackingCallBack: growthBookTrackingCallBack,
-      featureUsageCallback: featureUsageCallback,
-      features: gbFeatures,
-      stickyBucketService: stickyBucketService,
-      backgroundSync: backgroundSync,
-      remoteEval: remoteEval,
-      url: url
-    );
+        apiKey: apiKey,
+        encryptionKey: encryptionKey,
+        hostURL: hostURL,
+        enabled: enable,
+        qaMode: qaMode,
+        attributes: attributes,
+        forcedVariation: forcedVariations,
+        trackingCallBack: growthBookTrackingCallBack,
+        featureUsageCallback: featureUsageCallback,
+        features: gbFeatures,
+        stickyBucketService: stickyBucketService,
+        backgroundSync: backgroundSync,
+        remoteEval: remoteEval,
+        url: url);
     final gb = GrowthBookSDK._(
       context: gbContext,
       client: client,
@@ -87,13 +84,15 @@ class GBSDKBuilderApp {
     return this;
   }
 
-  GBSDKBuilderApp setStickyBucketService(StickyBucketService? stickyBucketService) {
+  GBSDKBuilderApp setStickyBucketService(
+      StickyBucketService? stickyBucketService) {
     this.stickyBucketService = stickyBucketService;
     return this;
   }
 
   /// Setter for featureUsageCallback. A callback that will be invoked every time a feature is viewed.
-  GBSDKBuilderApp setFeatureUsageCallback(GBFeatureUsageCallback featureUsageCallback) {
+  GBSDKBuilderApp setFeatureUsageCallback(
+      GBFeatureUsageCallback featureUsageCallback) {
     this.featureUsageCallback = featureUsageCallback;
     return this;
   }
@@ -112,7 +111,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
     GBFeatures? gbFeatures,
     SavedGroupsValues? savedGroups,
   })  : _context = context,
-        _evaluationContext = evaluationContext,
+        _evaluationContext =
+            evaluationContext ?? GBUtils.initializeEvalContext(context, null),
         _onInitializationFailure = onInitializationFailure,
         _refreshHandler = refreshHandler,
         _gbFeatures = gbFeatures,
@@ -123,7 +123,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
 
   final GBContext _context;
 
-  final EvaluationContext? _evaluationContext;
+  final EvaluationContext _evaluationContext;
 
   final BaseClient _baseClient;
 
@@ -218,16 +218,21 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
     if (assigned.containsKey(key)) {
       var assignedExperiment = assigned[key];
 
-      if (assignedExperiment!.experimentResult.inExperiment != result.inExperiment ||
-          assignedExperiment.experimentResult.variationID != result.variationID) {
+      if (assignedExperiment!.experimentResult.inExperiment !=
+              result.inExperiment ||
+          assignedExperiment.experimentResult.variationID !=
+              result.variationID) {
         updateSubscriptions(key: key, experiment: experiment, result: result);
       }
     }
   }
 
   void updateSubscriptions(
-      {required String key, required GBExperiment experiment, required GBExperimentResult result}) {
-    assigned[key] = AssignedExperiment(experiment: experiment, experimentResult: result);
+      {required String key,
+      required GBExperiment experiment,
+      required GBExperimentResult result}) {
+    assigned[key] =
+        AssignedExperiment(experiment: experiment, experimentResult: result);
     for (var subscription in subscriptions) {
       subscription(experiment, result);
     }
@@ -242,7 +247,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   }
 
   GBFeatureResult feature(String id) {
-    return FeatureEvaluator().evaluateFeature(GBUtils.initializeEvalContext(context, _refreshHandler), id);
+    return FeatureEvaluator().evaluateFeature(
+        GBUtils.initializeEvalContext(context, _refreshHandler), id);
   }
 
   GBExperimentResult run(GBExperiment experiment) {
@@ -253,7 +259,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
     return result;
   }
 
-  Map<StickyAttributeKey, StickyAssignmentsDocument> getStickyBucketAssignmentDocs() {
+  Map<StickyAttributeKey, StickyAssignmentsDocument>
+      getStickyBucketAssignmentDocs() {
     return _context.stickyBucketAssignmentDocs ?? {};
   }
 
@@ -276,7 +283,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
     _forcedFeatures = forcedFeatures;
   }
 
-  void setEncryptedFeatures(String encryptedString, String encryptionKey, [CryptoProtocol? subtle]) {
+  void setEncryptedFeatures(String encryptedString, String encryptionKey,
+      [CryptoProtocol? subtle]) {
     CryptoProtocol crypto = subtle ?? Crypto();
     var features = crypto.getFeaturesFromEncryptedFeatures(
       encryptedString,
@@ -300,7 +308,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
 
   Future<void> refreshStickyBucketService(FeaturedDataModel? data) async {
     if (context.stickyBucketService != null) {
-      await GBUtils.refreshStickyBuckets(_evaluationContext!, data, _evaluationContext!.userContext.attributes ?? {});
+      await GBUtils.refreshStickyBuckets(_evaluationContext, data,
+          _evaluationContext.userContext.attributes ?? {});
     }
   }
 
@@ -317,9 +326,10 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
     );
 
     RemoteEvalModel payload = RemoteEvalModel(
-      attributes: _evaluationContext?.userContext.attributes ?? {},
+      attributes: _evaluationContext.userContext.attributes ?? {},
       forcedFeatures: _forcedFeatures,
-      forcedVariations: _evaluationContext?.userContext.forcedVariationsMap ?? {},
+      forcedVariations:
+          _evaluationContext.userContext.forcedVariationsMap ?? {},
     );
 
     await featureViewModel.fetchFeatures(
@@ -331,7 +341,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
 
   /// The evalFeature method takes a single string argument, which is the unique identifier for the feature and returns a FeatureResult object.
   GBFeatureResult evalFeature(String id) {
-    return FeatureEvaluator().evaluateFeature(GBUtils.initializeEvalContext(context, _refreshHandler), id);
+    return FeatureEvaluator().evaluateFeature(
+        GBUtils.initializeEvalContext(context, _refreshHandler), id);
   }
 
   /// The isOn method takes a single string argument, which is the unique identifier for the feature and returns the feature state on/off
@@ -340,7 +351,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   }
 
   @override
-  void savedGroupsFetchFailed({required GBError? error, required bool isRemote}) {
+  void savedGroupsFetchFailed(
+      {required GBError? error, required bool isRemote}) {
     _onInitializationFailure?.call(error);
     if (isRemote) {
       if (_refreshHandler != null) {
@@ -350,7 +362,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   }
 
   @override
-  void savedGroupsFetchedSuccessfully({required SavedGroupsValues savedGroups, required bool isRemote}) {
+  void savedGroupsFetchedSuccessfully(
+      {required SavedGroupsValues savedGroups, required bool isRemote}) {
     _context.savedGroups = savedGroups;
     if (isRemote) {
       if (_refreshHandler != null) {


### PR DESCRIPTION
- Exported StickyAssignmentsDocument to allow custom implementations of GBStickyBucketingService
- Initialized evaluationContext to prevent null check exceptions