### PR TITLE
Ttl feature

### DIFF
--- a/lib/src/Features/features_view_model.dart
+++ b/lib/src/Features/features_view_model.dart
@@ -14,11 +14,15 @@ class FeatureViewModel {
     required this.source,
     required this.encryptionKey,
     this.backgroundSync,
+    this.TTLSeconds = 60,
   });
+
   final FeaturesFlowDelegate delegate;
   final FeatureDataSource source;
   final String encryptionKey;
   final bool? backgroundSync;
+  final int TTLSeconds;
+  int? _expiresAt;
 
   final CachingManager manager = CachingManager();
   final utf8Encoder = const Utf8Encoder();
@@ -28,7 +32,8 @@ class FeatureViewModel {
     await source.fetchFeatures(
       featureRefreshStrategy: FeatureRefreshStrategy.SERVER_SENT_EVENTS,
       (data) {
-        delegate.featuresFetchedSuccessfully(gbFeatures: data.features!, isRemote: false);
+        delegate.featuresFetchedSuccessfully(
+            gbFeatures: data.features!, isRemote: false);
         prepareFeaturesData(data);
       },
       (e, s) => delegate.featuresFetchFailed(
@@ -41,16 +46,19 @@ class FeatureViewModel {
     );
   }
 
-  Future<void> fetchFeatures(String? apiUrl, {bool remoteEval = false, RemoteEvalModel? payload}) async {
-    final receivedData = await manager.getContent(fileName: Constant.featureCache);
+  Future<void> fetchFeatures(String? apiUrl,
+      {bool remoteEval = false, RemoteEvalModel? payload}) async {
+    final receivedData =
+        await manager.getContent(fileName: Constant.featureCache);
 
-    if (receivedData == null) {
+    if (receivedData == null || isCacheExpired()) {
       await source.fetchFeatures(
         (data) {
           delegate.featuresFetchedSuccessfully(
             gbFeatures: data.features!,
             isRemote: false,
           );
+          refreshExpiresAt();
           cacheFeatures(data);
         },
         (e, s) => delegate.featuresFetchFailed(
@@ -73,43 +81,31 @@ class FeatureViewModel {
           }
         });
       } else {
-        featureMap = FeaturedDataModel.fromJson(receiveFeatureJsonMap).features ?? {};
+        featureMap =
+            FeaturedDataModel.fromJson(receiveFeatureJsonMap).features ?? {};
       }
 
-      delegate.featuresFetchedSuccessfully(gbFeatures: featureMap, isRemote: false);
+      delegate.featuresFetchedSuccessfully(
+          gbFeatures: featureMap, isRemote: false);
     }
 
-    if (apiUrl != null) {
-      if (remoteEval) {
-        await source.fetchRemoteEval(
-            apiUrl: apiUrl,
-            params: payload,
-            onSuccess: (data) {
-              prepareFeaturesData(data);
-            },
-            onError: (e, s) {
-              delegate.featuresFetchFailed(
-                error: GBError(
-                  error: e,
-                  stackTrace: s.toString(),
-                ),
-                isRemote: true,
-              );
-            });
-      } else {
-        await source.fetchFeatures(
-          (data) {
+    if (apiUrl != null && remoteEval) {
+      await source.fetchRemoteEval(
+          apiUrl: apiUrl,
+          params: payload,
+          onSuccess: (data) {
             prepareFeaturesData(data);
           },
-          (e, s) => delegate.featuresFetchFailed(
-            error: GBError(
-              error: e,
-              stackTrace: s.toString(),
-            ),
-            isRemote: true,
-          ),
-        );
-      }
+          onError: (e, s) {
+            delegate.featuresFetchFailed(
+              error: GBError(
+                error: e,
+                stackTrace: s.toString(),
+              ),
+              isRemote: true,
+            );
+          });
+      refreshExpiresAt();
     }
   }
 
@@ -128,7 +124,8 @@ class FeatureViewModel {
   void handleValidFeatures(FeaturedDataModel data) {
     if (data.features != null && data.encryptedFeatures == null) {
       delegate.featuresAPIModelSuccessfully(data);
-      delegate.featuresFetchedSuccessfully(gbFeatures: data.features!, isRemote: true);
+      delegate.featuresFetchedSuccessfully(
+          gbFeatures: data.features!, isRemote: true);
       final featureData = utf8Encoder.convert(jsonEncode(data));
       final featureDataOnUint8List = Uint8List.fromList(featureData);
       manager.putData(
@@ -137,8 +134,10 @@ class FeatureViewModel {
       );
 
       if (data.savedGroups != null) {
-        delegate.savedGroupsFetchedSuccessfully(savedGroups: data.savedGroups!, isRemote: true);
-        final savedGroupsData = utf8Encoder.convert(jsonEncode(data.savedGroups));
+        delegate.savedGroupsFetchedSuccessfully(
+            savedGroups: data.savedGroups!, isRemote: true);
+        final savedGroupsData =
+            utf8Encoder.convert(jsonEncode(data.savedGroups));
         final savedGroupsDataOnUint8List = Uint8List.fromList(savedGroupsData);
         manager.putData(
           fileName: Constant.savedGroupsCache,
@@ -174,7 +173,8 @@ class FeatureViewModel {
       );
 
       if (extractedFeatures != null) {
-        delegate.featuresFetchedSuccessfully(gbFeatures: extractedFeatures, isRemote: true);
+        delegate.featuresFetchedSuccessfully(
+            gbFeatures: extractedFeatures, isRemote: true);
         final featureData = utf8Encoder.convert(jsonEncode(extractedFeatures));
         final featureDataOnUint8List = Uint8List.fromList(featureData);
         manager.putData(
@@ -214,8 +214,10 @@ class FeatureViewModel {
       );
 
       if (extractedSavedGroups != null) {
-        delegate.savedGroupsFetchedSuccessfully(savedGroups: extractedSavedGroups, isRemote: false);
-        final savedGroupsData = utf8Encoder.convert(jsonEncode(extractedSavedGroups));
+        delegate.savedGroupsFetchedSuccessfully(
+            savedGroups: extractedSavedGroups, isRemote: false);
+        final savedGroupsData =
+            utf8Encoder.convert(jsonEncode(extractedSavedGroups));
         final savedGroupsDataOnUint8List = Uint8List.fromList(savedGroupsData);
         manager.putData(
           fileName: Constant.savedGroupsCache,
@@ -256,5 +258,18 @@ class FeatureViewModel {
       fileName: Constant.featureCache,
       content: featureDataOnUint8List,
     );
+  }
+
+  void refreshExpiresAt() {
+    _expiresAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 + TTLSeconds;
+  }
+
+  bool isCacheExpired() {
+    if (_expiresAt == null) {
+      return true;
+    } else {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      return now >= _expiresAt!;
+    }
   }
 }

--- a/lib/src/growth_book_sdk.dart
+++ b/lib/src/growth_book_sdk.dart
@@ -300,7 +300,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
       attributes: _evaluationContext?.userContext.attributes ?? {},
       forcedFeatures: _forcedFeatures,
       forcedVariations:
-          _evaluationContext?.userContext.forcedVariationsMap ?? {},
+          _evaluationContext.userContext.forcedVariationsMap ?? {},
     );
 
     await _featureViewModel.fetchFeatures(
@@ -312,7 +312,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
 
   /// The evalFeature method takes a single string argument, which is the unique identifier for the feature and returns a FeatureResult object.
   GBFeatureResult evalFeature(String id) {
-    _featureViewModel.fetchFeatures(context.getFeaturesURL());
+     _featureViewModel.fetchFeatures();
     return FeatureEvaluator().evaluateFeature(
         GBUtils.initializeEvalContext(context, _refreshHandler), id);
   }

--- a/lib/src/growth_book_sdk.dart
+++ b/lib/src/growth_book_sdk.dart
@@ -14,24 +14,23 @@ typedef VoidCallback = void Function();
 typedef OnInitializationFailure = void Function(GBError? error);
 
 class GBSDKBuilderApp {
-  GBSDKBuilderApp({
-    required this.hostURL,
-    required this.apiKey,
-    this.encryptionKey,
-    required this.growthBookTrackingCallBack,
-    this.attributes = const <String, dynamic>{},
-    this.qaMode = false,
-    this.enable = true,
-    this.forcedVariations = const <String, int>{},
-    this.client,
-    this.gbFeatures = const {},
-    this.onInitializationFailure,
-    this.refreshHandler,
-    this.stickyBucketService,
-    this.backgroundSync = false,
-    this.remoteEval = false,
-    this.url
-  });
+  GBSDKBuilderApp(
+      {required this.hostURL,
+      required this.apiKey,
+      this.encryptionKey,
+      required this.growthBookTrackingCallBack,
+      this.attributes = const <String, dynamic>{},
+      this.qaMode = false,
+      this.enable = true,
+      this.forcedVariations = const <String, int>{},
+      this.client,
+      this.gbFeatures = const {},
+      this.onInitializationFailure,
+      this.refreshHandler,
+      this.stickyBucketService,
+      this.backgroundSync = false,
+      this.remoteEval = false,
+      this.url});
 
   final String apiKey;
   final String? encryptionKey;
@@ -52,30 +51,27 @@ class GBSDKBuilderApp {
   StickyBucketService? stickyBucketService;
   GBFeatureUsageCallback? featureUsageCallback;
 
-
   Future<GrowthBookSDK> initialize() async {
     final gbContext = GBContext(
-      apiKey: apiKey,
-      encryptionKey: encryptionKey,
-      hostURL: hostURL,
-      enabled: enable,
-      qaMode: qaMode,
-      attributes: attributes,
-      forcedVariation: forcedVariations,
-      trackingCallBack: growthBookTrackingCallBack,
-      featureUsageCallback: featureUsageCallback,
-      features: gbFeatures,
-      stickyBucketService: stickyBucketService,
-      backgroundSync: backgroundSync,
-      remoteEval: remoteEval,
-      url: url
-    );
+        apiKey: apiKey,
+        encryptionKey: encryptionKey,
+        hostURL: hostURL,
+        enabled: enable,
+        qaMode: qaMode,
+        attributes: attributes,
+        forcedVariation: forcedVariations,
+        trackingCallBack: growthBookTrackingCallBack,
+        featureUsageCallback: featureUsageCallback,
+        features: gbFeatures,
+        stickyBucketService: stickyBucketService,
+        backgroundSync: backgroundSync,
+        remoteEval: remoteEval,
+        url: url);
     final gb = GrowthBookSDK._(
       context: gbContext,
       client: client,
       onInitializationFailure: onInitializationFailure,
       refreshHandler: refreshHandler,
-      gbFeatures: gbFeatures,
     );
     await gb.refresh();
     await gb.refreshStickyBucketService(null);
@@ -87,13 +83,15 @@ class GBSDKBuilderApp {
     return this;
   }
 
-  GBSDKBuilderApp setStickyBucketService(StickyBucketService? stickyBucketService) {
+  GBSDKBuilderApp setStickyBucketService(
+      StickyBucketService? stickyBucketService) {
     this.stickyBucketService = stickyBucketService;
     return this;
   }
 
   /// Setter for featureUsageCallback. A callback that will be invoked every time a feature is viewed.
-  GBSDKBuilderApp setFeatureUsageCallback(GBFeatureUsageCallback featureUsageCallback) {
+  GBSDKBuilderApp setFeatureUsageCallback(
+      GBFeatureUsageCallback featureUsageCallback) {
     this.featureUsageCallback = featureUsageCallback;
     return this;
   }
@@ -109,31 +107,32 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
     EvaluationContext? evaluationContext,
     BaseClient? client,
     CacheRefreshHandler? refreshHandler,
-    GBFeatures? gbFeatures,
-    SavedGroupsValues? savedGroups,
   })  : _context = context,
         _evaluationContext = evaluationContext,
         _onInitializationFailure = onInitializationFailure,
         _refreshHandler = refreshHandler,
-        _gbFeatures = gbFeatures,
-        _savedGroups = savedGroups,
         _baseClient = client ?? DioClient(),
         _forcedFeatures = [],
-        _attributeOverrides = {};
+        _attributeOverrides = {} {
+    _featureViewModel = FeatureViewModel(
+      delegate: this,
+      source: FeatureDataSource(context: _context, client: _baseClient),
+      encryptionKey: _context.encryptionKey ?? "",
+      backgroundSync: _context.backgroundSync,
+    );
+  }
 
   final GBContext _context;
 
   final EvaluationContext? _evaluationContext;
+
+  late FeatureViewModel _featureViewModel;
 
   final BaseClient _baseClient;
 
   final OnInitializationFailure? _onInitializationFailure;
 
   final CacheRefreshHandler? _refreshHandler;
-
-  final GBFeatures? _gbFeatures;
-
-  final SavedGroupsValues? _savedGroups;
 
   List<dynamic> _forcedFeatures;
 
@@ -173,41 +172,17 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   }
 
   Future<void> autoRefresh() async {
-    final featureViewModel = FeatureViewModel(
-      backgroundSync: _context.backgroundSync,
-      encryptionKey: _context.encryptionKey ?? "",
-      delegate: this,
-      source: FeatureDataSource(
-        client: _baseClient,
-        context: _context,
-      ),
-    );
     if (_context.backgroundSync) {
-      await featureViewModel.connectBackgroundSync();
+      await _featureViewModel.connectBackgroundSync();
     }
   }
 
   Future<void> refresh() async {
-    final featureViewModel = FeatureViewModel(
-      backgroundSync: _context.backgroundSync,
-      encryptionKey: _context.encryptionKey ?? "",
-      delegate: this,
-      source: FeatureDataSource(
-        client: _baseClient,
-        context: _context,
-      ),
-    );
-    if (_gbFeatures != null) {
-      _context.features = _gbFeatures!;
-    }
-    if (_savedGroups != null) {
-      _context.savedGroups = _savedGroups!;
-    }
     if (_context.remoteEval) {
       refreshForRemoteEval();
     } else {
       log(context.getFeaturesURL().toString());
-      await featureViewModel.fetchFeatures(context.getFeaturesURL());
+      await _featureViewModel.fetchFeatures(context.getFeaturesURL());
     }
   }
 
@@ -218,16 +193,21 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
     if (assigned.containsKey(key)) {
       var assignedExperiment = assigned[key];
 
-      if (assignedExperiment!.experimentResult.inExperiment != result.inExperiment ||
-          assignedExperiment.experimentResult.variationID != result.variationID) {
+      if (assignedExperiment!.experimentResult.inExperiment !=
+              result.inExperiment ||
+          assignedExperiment.experimentResult.variationID !=
+              result.variationID) {
         updateSubscriptions(key: key, experiment: experiment, result: result);
       }
     }
   }
 
   void updateSubscriptions(
-      {required String key, required GBExperiment experiment, required GBExperimentResult result}) {
-    assigned[key] = AssignedExperiment(experiment: experiment, experimentResult: result);
+      {required String key,
+      required GBExperiment experiment,
+      required GBExperimentResult result}) {
+    assigned[key] =
+        AssignedExperiment(experiment: experiment, experimentResult: result);
     for (var subscription in subscriptions) {
       subscription(experiment, result);
     }
@@ -242,7 +222,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   }
 
   GBFeatureResult feature(String id) {
-    return FeatureEvaluator().evaluateFeature(GBUtils.initializeEvalContext(context, _refreshHandler), id);
+    return FeatureEvaluator().evaluateFeature(
+        GBUtils.initializeEvalContext(context, _refreshHandler), id);
   }
 
   GBExperimentResult run(GBExperiment experiment) {
@@ -253,7 +234,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
     return result;
   }
 
-  Map<StickyAttributeKey, StickyAssignmentsDocument> getStickyBucketAssignmentDocs() {
+  Map<StickyAttributeKey, StickyAssignmentsDocument>
+      getStickyBucketAssignmentDocs() {
     return _context.stickyBucketAssignmentDocs ?? {};
   }
 
@@ -276,7 +258,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
     _forcedFeatures = forcedFeatures;
   }
 
-  void setEncryptedFeatures(String encryptedString, String encryptionKey, [CryptoProtocol? subtle]) {
+  void setEncryptedFeatures(String encryptedString, String encryptionKey,
+      [CryptoProtocol? subtle]) {
     CryptoProtocol crypto = subtle ?? Crypto();
     var features = crypto.getFeaturesFromEncryptedFeatures(
       encryptedString,
@@ -300,29 +283,21 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
 
   Future<void> refreshStickyBucketService(FeaturedDataModel? data) async {
     if (context.stickyBucketService != null) {
-      await GBUtils.refreshStickyBuckets(_evaluationContext!, data, _evaluationContext!.userContext.attributes ?? {});
+      await GBUtils.refreshStickyBuckets(_evaluationContext!, data,
+          _evaluationContext!.userContext.attributes ?? {});
     }
   }
 
   Future<void> refreshForRemoteEval() async {
     if (!context.remoteEval) return;
-    final featureViewModel = FeatureViewModel(
-      backgroundSync: _context.backgroundSync,
-      encryptionKey: _context.encryptionKey ?? "",
-      delegate: this,
-      source: FeatureDataSource(
-        client: _baseClient,
-        context: _context,
-      ),
-    );
-
     RemoteEvalModel payload = RemoteEvalModel(
       attributes: _evaluationContext?.userContext.attributes ?? {},
       forcedFeatures: _forcedFeatures,
-      forcedVariations: _evaluationContext?.userContext.forcedVariationsMap ?? {},
+      forcedVariations:
+          _evaluationContext?.userContext.forcedVariationsMap ?? {},
     );
 
-    await featureViewModel.fetchFeatures(
+    await _featureViewModel.fetchFeatures(
       context.getRemoteEvalUrl(),
       remoteEval: context.remoteEval,
       payload: payload,
@@ -331,7 +306,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
 
   /// The evalFeature method takes a single string argument, which is the unique identifier for the feature and returns a FeatureResult object.
   GBFeatureResult evalFeature(String id) {
-    return FeatureEvaluator().evaluateFeature(GBUtils.initializeEvalContext(context, _refreshHandler), id);
+    return FeatureEvaluator().evaluateFeature(
+        GBUtils.initializeEvalContext(context, _refreshHandler), id);
   }
 
   /// The isOn method takes a single string argument, which is the unique identifier for the feature and returns the feature state on/off
@@ -340,7 +316,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   }
 
   @override
-  void savedGroupsFetchFailed({required GBError? error, required bool isRemote}) {
+  void savedGroupsFetchFailed(
+      {required GBError? error, required bool isRemote}) {
     _onInitializationFailure?.call(error);
     if (isRemote) {
       if (_refreshHandler != null) {
@@ -350,7 +327,8 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   }
 
   @override
-  void savedGroupsFetchedSuccessfully({required SavedGroupsValues savedGroups, required bool isRemote}) {
+  void savedGroupsFetchedSuccessfully(
+      {required SavedGroupsValues savedGroups, required bool isRemote}) {
     _context.savedGroups = savedGroups;
     if (isRemote) {
       if (_refreshHandler != null) {


### PR DESCRIPTION
This PR introduces a stale-while-revalidate approach for feature fetching, in line with the caching strategy described in the [GrowthBook documentation](https://docs.growthbook.io/lib/build-your-own#fetching-and-caching-features).

- Added TTL support for cached feature data.
- Implemented a stale-while-revalidate strategy:
  - If the cache exists and is still valid, features are returned immediately from cache.
  - If the cache is expired or missing, features are fetched from the API and the cache is updated.