### PR TITLE
Add string comparison for LTE and GTE operators in condition evaluator

### DIFF
--- a/lib/src/Evaluator/condition_evaluator.dart
+++ b/lib/src/Evaluator/condition_evaluator.dart
@@ -384,6 +384,9 @@ class GBConditionEvaluator {
 
         /// Evaluate LTE operator - whether attribute less than or equal to condition
         case '\$lte':
+          if (conditionValue is String && attributeValue is String) {
+            return attributeValue.compareTo(conditionValue) <= 0;
+          }
           evaluatedValue = (sourcePrimitiveValue ?? 0.0) <= (targetPrimitiveValue ?? 0);
           break;
 
@@ -396,6 +399,9 @@ class GBConditionEvaluator {
           break;
 
         case '\$gte':
+          if (conditionValue is String && attributeValue is String) {
+            return attributeValue.compareTo(conditionValue) >= 0;
+          }
           evaluatedValue = (sourcePrimitiveValue ?? 0.0) >= (targetPrimitiveValue ?? 0);
           break;
 


### PR DESCRIPTION
I simply took the lt and gt logic and add `=`

<img width="793" height="572" alt="image" src="https://github.com/user-attachments/assets/a13ab627-5862-4ad5-a651-4e1da1515352" />

fixes #92 