### PR TITLE
Mc/bug fixes

### DIFF
--- a/lib/src/Evaluator/condition_evaluator.dart
+++ b/lib/src/Evaluator/condition_evaluator.dart
@@ -384,6 +384,9 @@ class GBConditionEvaluator {
 
         /// Evaluate LTE operator - whether attribute less than or equal to condition
         case '\$lte':
+          if (conditionValue is String && attributeValue is String) {
+            return attributeValue.compareTo(conditionValue) <= 0;
+          }
           evaluatedValue = (sourcePrimitiveValue ?? 0.0) <= (targetPrimitiveValue ?? 0);
           break;
 
@@ -396,6 +399,9 @@ class GBConditionEvaluator {
           break;
 
         case '\$gte':
+          if (conditionValue is String && attributeValue is String) {
+            return attributeValue.compareTo(conditionValue) >= 0;
+          }
           evaluatedValue = (sourcePrimitiveValue ?? 0.0) >= (targetPrimitiveValue ?? 0);
           break;
 

--- a/lib/src/Features/features_view_model.dart
+++ b/lib/src/Features/features_view_model.dart
@@ -36,7 +36,7 @@ class FeatureViewModel {
       featureRefreshStrategy: FeatureRefreshStrategy.SERVER_SENT_EVENTS,
       (data) {
         delegate.featuresFetchedSuccessfully(
-            gbFeatures: data.features!, isRemote: false);
+            gbFeatures: data.features!, isRemote: true);
         prepareFeaturesData(data);
       },
       (e, s) => delegate.featuresFetchFailed(
@@ -44,7 +44,7 @@ class FeatureViewModel {
           error: e,
           stackTrace: s.toString(),
         ),
-        isRemote: false,
+        isRemote: true,
       ),
     );
   }
@@ -113,7 +113,7 @@ class FeatureViewModel {
   void _handleSuccess(FeaturedDataModel data) {
   delegate.featuresFetchedSuccessfully(
     gbFeatures: data.features!,
-    isRemote: false,
+    isRemote: true,  // This is a network fetch, so it should be remote
   );
   cacheFeatures(data);
   refreshExpiresAt();

--- a/lib/src/growth_book_sdk.dart
+++ b/lib/src/growth_book_sdk.dart
@@ -128,7 +128,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
 
   final GBContext _context;
 
-  final EvaluationContext _evaluationContext;
+  EvaluationContext _evaluationContext;
 
   late FeatureViewModel _featureViewModel;
 
@@ -152,15 +152,26 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   /// Retrieved features.
   dynamic get features => _context.features;
 
+  /// Updates the evaluation context to reflect current context state.
+  /// This method should be called whenever the underlying GBContext changes
+  /// to ensure that the evaluation context remains synchronized.
+  /// 
+  /// This approach maintains a single source of truth for the evaluation context
+  /// instead of creating new contexts on every evaluation, which is more efficient
+  /// and prevents bugs caused by stale evaluation contexts.
+  void _updateEvaluationContext() {
+    _evaluationContext = GBUtils.initializeEvalContext(_context, _refreshHandler);
+  }
+
   @override
   void featuresFetchedSuccessfully({
     required GBFeatures gbFeatures,
     required bool isRemote,
   }) {
     _context.features = gbFeatures;
-    // Sync features to evaluation context after refresh
-    _evaluationContext.globalContext.features = gbFeatures;
+    _updateEvaluationContext();
     if (isRemote) {
+      log('Features updated from remote source, triggering refresh handler');
       if (_refreshHandler != null) {
         _refreshHandler!(true);
       }
@@ -239,10 +250,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   }
 
   GBFeatureResult feature(String id) {
-    // Sync features to evaluation context (no fetchFeatures to avoid cycles)
-    _evaluationContext.globalContext.features = _context.features;
-    // Clear stack context to avoid false cyclic prerequisite detection
-    _evaluationContext.stackContext.evaluatedFeatures.clear();
+    _featureViewModel.fetchFeatures(context.getFeaturesURL());
     return FeatureEvaluator().evaluateFeature(_evaluationContext, id);
   }
 
@@ -267,7 +275,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   /// Replaces the Map of user attributes that are used to assign variations
   void setAttributes(Map<String, dynamic> attributes) {
     _context.attributes = attributes;
-    _evaluationContext.userContext.attributes = attributes;
+    _updateEvaluationContext();
     refreshStickyBucketService(null);
   }
 
@@ -276,6 +284,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
 
   void setAttributeOverrides(dynamic overrides) {
     _attributeOverrides = jsonDecode(overrides) as Map<String, dynamic>;
+    _updateEvaluationContext();
     if (context.stickyBucketService != null) {
       refreshStickyBucketService(null);
     }
@@ -285,6 +294,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   /// The setForcedFeatures method updates forced features
   void setForcedFeatures(List<dynamic> forcedFeatures) {
     _forcedFeatures = forcedFeatures;
+    _updateEvaluationContext();
   }
 
   void setEncryptedFeatures(String encryptedString, String encryptionKey,
@@ -297,13 +307,13 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
 
     if (features != null) {
       _context.features = features;
-      // Sync features to evaluation context
-      _evaluationContext.globalContext.features = features;
+      _updateEvaluationContext();
     }
   }
 
   void setForcedVariations(Map<String, dynamic> forcedVariations) {
     _context.forcedVariation = forcedVariations;
+    _updateEvaluationContext();
     refreshForRemoteEval();
   }
 
@@ -316,9 +326,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
     if (context.stickyBucketService != null) {
       await GBUtils.refreshStickyBuckets(_context, data,
           _evaluationContext.userContext.attributes ?? {});
-      // Sync the loaded assignments to userContext
-      _evaluationContext.userContext.stickyBucketAssignmentDocs = 
-          _context.stickyBucketAssignmentDocs;
+      _updateEvaluationContext();
     }
   }
 
@@ -340,7 +348,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
 
   /// The evalFeature method takes a single string argument, which is the unique identifier for the feature and returns a FeatureResult object.
   GBFeatureResult evalFeature(String id) {
-    // Sync features to evaluation context (no fetchFeatures to avoid cycles)
+     // Sync features to evaluation context (no fetchFeatures to avoid cycles)
     _evaluationContext.globalContext.features = _context.features;
     // Clear stack context to avoid false cyclic prerequisite detection
     _evaluationContext.stackContext.evaluatedFeatures.clear();
@@ -367,6 +375,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
   void savedGroupsFetchedSuccessfully(
       {required SavedGroupsValues savedGroups, required bool isRemote}) {
     _context.savedGroups = savedGroups;
+    _updateEvaluationContext();
     if (isRemote) {
       if (_refreshHandler != null) {
         _refreshHandler!(true);

--- a/test/test_cases/test_case.dart
+++ b/test/test_cases/test_case.dart
@@ -915,6 +915,69 @@ const String gbTestCases = r'''
       false
     ],
     [
+      "ISO date $gte/$lte - previously broken operators fix",
+      {
+        "subscriptionDate": {
+          "$gte": "2025-04-28T12:00",
+          "$lte": "2025-12-31T23:59"
+        }
+      },
+      {
+        "subscriptionDate": "2025-06-15T14:30"
+      },
+      true
+    ],
+    [
+      "ISO date $gt/$lt - ensure existing operators still work",
+      {
+        "lastLogin": {
+          "$gt": "2025-01-01T00:00",
+          "$lt": "2025-12-31T23:59"
+        }
+      },
+      {
+        "lastLogin": "2025-06-15T12:30"
+      },
+      true
+    ],
+    [
+      "ISO date with timezone - edge case handling",
+      {
+        "scheduledAt": {
+          "$lte": "2025-08-20T15:00:00+05:30"
+        }
+      },
+      {
+        "scheduledAt": "2025-08-20T14:30:00+05:30"
+      },
+      true
+    ],
+    [
+      "ISO date with milliseconds - precision handling",
+      {
+        "timestamp": {
+          "$gte": "2025-01-15T10:30:45.123Z"
+        }
+      },
+      {
+        "timestamp": "2025-01-15T10:30:45.456Z"
+      },
+      true
+    ],
+    [
+      "ISO date boundary test - $gt passes but $lt fails",
+      {
+        "lastLogin": {
+          "$gt": "2025-01-01T00:00",
+          "$lt": "2025-06-01T00:00"
+        }
+      },
+      {
+        "lastLogin": "2025-12-31T23:59"
+      },
+      false
+    ],
+    [
       "nested value is null",
       {
         "address.state": "CA"


### PR DESCRIPTION
- add string comparisons for `lte` and `gte`. fixes [92](https://github.com/growthbook/growthbook-flutter/issues/92)
- Fixes of inconsistent refresh handler triggers.
- fixes for -- Sticky bucketing always uses stale documents.
- refresh evaluation context