### PR TITLE
fix: include .g.dart files in published packages

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -46,4 +46,5 @@ app.*.map.json
 /android/app/release
 
 # Generated files
-**/*.g.dart
+# NOTE: .g.dart files are needed in published packages for users
+# They are excluded from git via .gitignore but MUST be included in pub.dev


### PR DESCRIPTION

- Remove **/*.g.dart from .pubignore
- Fixes missing generated files in versions 3.9.12, 3.9.13, 3.9.14

The files are still excluded from git via .gitignore but now included in pub.dev packages. Closes #82 