### PR TITLE
correct on/off state recognition for 0 and false feature values

### DIFF
--- a/lib/src/Evaluator/feature_evaluator.dart
+++ b/lib/src/Evaluator/feature_evaluator.dart
@@ -237,8 +237,6 @@ class FeatureEvaluator {
     String? ruleId = ""
   }) {
     var isFalse = value == null ||
-        value.toString() == 'false' ||
-        value.toString() == '0' ||
         (value.toString().isEmpty && value is! Map && value is! List);
     return GBFeatureResult(
       value: value,


### PR DESCRIPTION
In this PR, we:

Correct the prepareResult function's isFalse condition, which previously did not correctly recognize features with defaultValue: false, 0, or "false".
Now, these values are treated as ON, since they are explicitly set.