### PR TITLE
feat: add support for regexi operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,68 @@ sdk.setAttributes({
 // This is configured in GrowthBook dashboard, not in code
 ```
 
+### Condition Operators
+
+The SDK supports the following operators in targeting conditions:
+
+#### Comparison
+
+| Operator | Description |
+|----------|-------------|
+| `$eq` | Equal to |
+| `$ne` | Not equal to |
+| `$lt` | Less than |
+| `$lte` | Less than or equal |
+| `$gt` | Greater than |
+| `$gte` | Greater than or equal |
+
+#### Membership
+
+| Operator | Description |
+|----------|-------------|
+| `$in` | Value is in array |
+| `$nin` | Value is not in array |
+| `$all` | Array contains all values |
+| `$ini` | Value is in array (case-insensitive string comparison) |
+| `$nini` | Value is not in array (case-insensitive string comparison) |
+| `$alli` | Array contains all values (case-insensitive string comparison) |
+
+> For `$ini`, `$nini`, and `$alli`: string values are compared after lowercasing; non-string values (numbers, booleans, null) are compared as-is.
+
+#### Regex
+
+| Operator | Description |
+|----------|-------------|
+| `$regex` | Matches regex (case-sensitive) |
+| `$notRegex` | Does not match regex (case-sensitive) |
+| `$regexi` | Matches regex (case-insensitive) |
+| `$notRegexi` | Does not match regex (case-insensitive) |
+
+#### Other
+
+| Operator | Description |
+|----------|-------------|
+| `$exists` | Attribute exists (`true`) or is absent (`false`) |
+| `$type` | Attribute type matches string (`"string"`, `"number"`, `"boolean"`, `"array"`, `"object"`, `"null"`) |
+| `$not` | Negates a condition |
+| `$size` | Array length matches condition |
+| `$elemMatch` | At least one array element matches condition |
+| `$vgt` / `$vlt` / `$vgte` / `$vlte` / `$veq` / `$vne` | Semantic version comparison |
+
+```dart
+// Example: case-insensitive membership
+// Matches users where country is "us", "US", "Us", etc.
+final condition = {
+  'country': {'\$ini': ['US', 'CA', 'GB']}
+};
+
+// Example: case-insensitive regex
+// Matches "Hello", "hello", "HELLO", etc.
+final condition2 = {
+  'greeting': {'\$regexi': '^hello'}
+};
+```
+
 ---
 
 ## 🔧 Advanced Features

--- a/lib/src/Evaluator/condition_evaluator.dart
+++ b/lib/src/Evaluator/condition_evaluator.dart
@@ -87,7 +87,8 @@ class GBConditionEvaluator {
   }
 
   /// Evaluate OR conditions against given attributes
-  bool isEvalOr(Map<String, dynamic> attributes, List conditionObj, SavedGroupsValues savedGroups) {
+  bool isEvalOr(Map<String, dynamic> attributes, List conditionObj,
+      SavedGroupsValues savedGroups) {
     // If conditionObj is empty, return true
     if (conditionObj.isEmpty) {
       return true;
@@ -106,7 +107,8 @@ class GBConditionEvaluator {
   }
 
   /// Evaluate AND conditions against given attributes
-  bool isEvalAnd(dynamic attributes, List conditionObj, SavedGroupsValues savedGroups) {
+  bool isEvalAnd(
+      dynamic attributes, List conditionObj, SavedGroupsValues savedGroups) {
     // Loop through the conditionObjects
 
     // Loop through the conditionObjects
@@ -186,10 +188,17 @@ class GBConditionEvaluator {
   }
 
   ///Evaluates Condition Value against given condition & attributes
-  bool isEvalConditionValue(dynamic conditionValue, dynamic attributeValue, SavedGroupsValues savedGroups) {
+  bool isEvalConditionValue(dynamic conditionValue, dynamic attributeValue,
+      SavedGroupsValues savedGroups,
+      {bool inSensitive = false}) {
+    // Simple equality comparison with optional case-insensitivity
+    if (inSensitive && conditionValue is String && attributeValue is String) {
+      return conditionValue.toLowerCase() == attributeValue.toLowerCase();
+    }
     // If conditionValue is a string, number, boolean, return true if it's
     // "equal" to attributeValue and false if not.
-    if ((conditionValue as Object?).isPrimitive && (attributeValue as Object?).isPrimitive) {
+    if ((conditionValue as Object?).isPrimitive &&
+        (attributeValue as Object?).isPrimitive) {
       return conditionValue == attributeValue;
     }
 
@@ -218,7 +227,8 @@ class GBConditionEvaluator {
         for (var key in conditionValue.keys) {
           // If evalOperatorCondition(key, attributeValue, value)
           // is false, return false
-          if (!evalOperatorCondition(key, attributeValue, conditionValue[key], savedGroups)) {
+          if (!evalOperatorCondition(
+              key, attributeValue, conditionValue[key], savedGroups)) {
             return false;
           }
         }
@@ -238,7 +248,8 @@ class GBConditionEvaluator {
 
   /// This checks if attributeValue is an array, and if so at least one of the
   /// array items must match the condition
-  bool elemMatch(dynamic attributeValue, dynamic condition, SavedGroupsValues savedGroups) {
+  bool elemMatch(dynamic attributeValue, dynamic condition,
+      SavedGroupsValues savedGroups) {
     // Loop through items in attributeValue
     if (attributeValue is List) {
       for (final item in attributeValue) {
@@ -284,7 +295,8 @@ class GBConditionEvaluator {
     if (operator == "\$exists") {
       if (conditionValue.toString() == 'false' && attributeValue == null) {
         return true;
-      } else if (conditionValue.toString() == 'true' && attributeValue != null) {
+      } else if (conditionValue.toString() == 'true' &&
+          attributeValue != null) {
         return true;
       }
     }
@@ -302,6 +314,13 @@ class GBConditionEvaluator {
         case '\$in':
           return isIn(attributeValue, conditionValue);
 
+        // Evaluate INI operator - attributeValue in the conditionValue array
+        case '\$ini':
+          return isIn(attributeValue, conditionValue, inSensitive: true);
+
+        case '\$nini':
+          return !isIn(attributeValue, conditionValue, inSensitive: true);
+
         /// Evaluate NIN operator - attributeValue not in the conditionValue
         /// array.
         case '\$nin':
@@ -309,27 +328,11 @@ class GBConditionEvaluator {
 
         /// Evaluate ALL operator - whether condition contains all attribute
         case '\$all':
-          if (attributeValue is List) {
-            /// Loop through conditionValue array
-            /// If none of the elements in the attributeValue array pass
-            /// evalConditionValue(conditionValue[i], attributeValue[j]),
-            /// return false.
-            for (var con in conditionValue) {
-              var result = false;
-              for (var attr in attributeValue) {
-                if (isEvalConditionValue(con, attr, savedGroups)) {
-                  result = true;
-                }
-              }
-              if (!result) {
-                return result;
-              }
-            }
-            return true;
-          } else {
-            /// If attributeValue is not an array, return false
-            return false;
-          }
+          return _isInAll(attributeValue, conditionValue, savedGroups,
+              inSensitive: false);
+        case '\$alli':
+          return _isInAll(attributeValue, conditionValue, savedGroups,
+              inSensitive: true);
         default:
           return false;
       }
@@ -342,15 +345,19 @@ class GBConditionEvaluator {
         /// Evaluate SIE operator - whether condition size is same as that
         /// of attribute
         case "\$size":
-          return isEvalConditionValue(conditionValue, attributeValue.length, savedGroups);
+          return isEvalConditionValue(
+              conditionValue, attributeValue.length, savedGroups);
 
         default:
       }
-    } else if ((attributeValue as Object?).isPrimitive && (conditionValue as Object?).isPrimitive) {
+    } else if ((attributeValue as Object?).isPrimitive &&
+        (conditionValue as Object?).isPrimitive) {
       final targetPrimitiveValue = double.tryParse(conditionValue.toString());
       final sourcePrimitiveValue = double.tryParse(attributeValue.toString());
-      final paddedVersionTarget = GBUtils.paddedVersionString(conditionValue.toString());
-      final paddedVersionSource = GBUtils.paddedVersionString(attributeValue?.toString() ?? '0.0');
+      final paddedVersionTarget =
+          GBUtils.paddedVersionString(conditionValue.toString());
+      final paddedVersionSource =
+          GBUtils.paddedVersionString(attributeValue?.toString() ?? '0.0');
 
       /// If condition is bool.
       bool evaluatedValue = false;
@@ -379,7 +386,8 @@ class GBConditionEvaluator {
           if (conditionValue is String && attributeValue is String) {
             return attributeValue.compareTo(conditionValue) < 0;
           }
-          evaluatedValue = (sourcePrimitiveValue ?? 0.0) < (targetPrimitiveValue ?? 0);
+          evaluatedValue =
+              (sourcePrimitiveValue ?? 0.0) < (targetPrimitiveValue ?? 0);
           break;
 
         /// Evaluate LTE operator - whether attribute less than or equal to condition
@@ -387,7 +395,8 @@ class GBConditionEvaluator {
           if (conditionValue is String && attributeValue is String) {
             return attributeValue.compareTo(conditionValue) <= 0;
           }
-          evaluatedValue = (sourcePrimitiveValue ?? 0.0) <= (targetPrimitiveValue ?? 0);
+          evaluatedValue =
+              (sourcePrimitiveValue ?? 0.0) <= (targetPrimitiveValue ?? 0);
           break;
 
         /// Evaluate GT operator - whether attribute greater than to condition
@@ -395,28 +404,45 @@ class GBConditionEvaluator {
           if (conditionValue is String && attributeValue is String) {
             return attributeValue.compareTo(conditionValue) > 0;
           }
-          evaluatedValue = (sourcePrimitiveValue ?? 0.0) > (targetPrimitiveValue ?? 0);
+          evaluatedValue =
+              (sourcePrimitiveValue ?? 0.0) > (targetPrimitiveValue ?? 0);
           break;
 
         case '\$gte':
           if (conditionValue is String && attributeValue is String) {
             return attributeValue.compareTo(conditionValue) >= 0;
           }
-          evaluatedValue = (sourcePrimitiveValue ?? 0.0) >= (targetPrimitiveValue ?? 0);
+          evaluatedValue =
+              (sourcePrimitiveValue ?? 0.0) >= (targetPrimitiveValue ?? 0);
           break;
 
         case '\$regex':
-          return _evalRegex(conditionValue: conditionValue, attributeValue: attributeValue, isCaseSensitive: true, negate: false);
+          return _evalRegex(
+              conditionValue: conditionValue,
+              attributeValue: attributeValue,
+              isCaseSensitive: true,
+              negate: false);
 
         case '\$regexi':
-           return _evalRegex(conditionValue: conditionValue, attributeValue: attributeValue, isCaseSensitive: false, negate: false);
+          return _evalRegex(
+              conditionValue: conditionValue,
+              attributeValue: attributeValue,
+              isCaseSensitive: false,
+              negate: false);
 
         case '\$notRegex':
-          return _evalRegex(conditionValue: conditionValue, attributeValue: attributeValue, isCaseSensitive: true, negate: true);
-
+          return _evalRegex(
+              conditionValue: conditionValue,
+              attributeValue: attributeValue,
+              isCaseSensitive: true,
+              negate: true);
 
         case '\$notRegexi':
-          return _evalRegex(conditionValue: conditionValue, attributeValue: attributeValue, isCaseSensitive: false, negate: true);
+          return _evalRegex(
+              conditionValue: conditionValue,
+              attributeValue: attributeValue,
+              isCaseSensitive: false,
+              negate: true);
 
         default:
           conditionValue = false;
@@ -426,29 +452,73 @@ class GBConditionEvaluator {
     return false;
   }
 
-  bool isIn(dynamic actualValue, List<dynamic> conditionValue) {
-    if (actualValue is List) {
-      return actualValue.any((el) => conditionValue.contains(el));
+  bool isIn(dynamic actualValue, List<dynamic> conditionValue,
+      {bool inSensitive = false}) {
+    dynamic _caseFole(dynamic value) {
+      if (inSensitive && value is String) {
+        return value.toLowerCase();
+      } else {
+        return value;
+      }
     }
-    return conditionValue.contains(actualValue);
+
+    if (actualValue is List) {
+      if (actualValue.isEmpty) {
+        return false;
+      }
+      return actualValue.any(
+        (attr) => conditionValue.any(
+          (cond) => _caseFole(attr) == _caseFole(cond),
+        ),
+      );
+    }
+    return conditionValue.any(
+      (cond) => _caseFole(actualValue) == _caseFole(cond),
+    );
   }
 
-  bool _evalRegex({
-    required dynamic conditionValue,
-    required dynamic attributeValue,
-    required bool isCaseSensitive,
-    required bool negate
-    }) {
-
-      if (conditionValue == null || attributeValue == null) {
-        return false;
+  bool _isInAll(dynamic actualValue, List<dynamic> conditionValue,
+      SavedGroupsValues savedGroups,
+      {bool inSensitive = false}) {
+    /// Loop through conditionValue array
+    /// If none of the elements in the attributeValue array pass
+    /// evalConditionValue(conditionValue[i], attributeValue[j]),
+    /// return false.
+    if (actualValue is List) {
+      for (var condition in conditionValue) {
+        var passed = false;
+        for (var attribute in actualValue) {
+          if (isEvalConditionValue(condition, attribute, savedGroups,
+              inSensitive: inSensitive)) {
+            passed = true;
+            break;
+          }
+        }
+        if (!passed) {
+          return false;
+        }
       }
-      try {
-        final regex = RegExp(conditionValue.toString(), caseSensitive: isCaseSensitive);
-        final matches = regex.hasMatch(attributeValue.toString());
-        return negate != matches;
-      } catch (_) {
-        return false;
-      }
+      return true;
+    } else {
+      return false;
     }
+  }
+
+  bool _evalRegex(
+      {required dynamic conditionValue,
+      required dynamic attributeValue,
+      required bool isCaseSensitive,
+      required bool negate}) {
+    if (conditionValue == null || attributeValue == null) {
+      return false;
+    }
+    try {
+      final regex =
+          RegExp(conditionValue.toString(), caseSensitive: isCaseSensitive);
+      final matches = regex.hasMatch(attributeValue.toString());
+      return negate != matches;
+    } catch (_) {
+      return false;
+    }
+  }
 }

--- a/lib/src/Evaluator/condition_evaluator.dart
+++ b/lib/src/Evaluator/condition_evaluator.dart
@@ -454,7 +454,7 @@ class GBConditionEvaluator {
 
   bool isIn(dynamic actualValue, List<dynamic> conditionValue,
       {bool inSensitive = false}) {
-    dynamic _caseFole(dynamic value) {
+    dynamic caseFole(dynamic value) {
       if (inSensitive && value is String) {
         return value.toLowerCase();
       } else {
@@ -468,12 +468,12 @@ class GBConditionEvaluator {
       }
       return actualValue.any(
         (attr) => conditionValue.any(
-          (cond) => _caseFole(attr) == _caseFole(cond),
+          (cond) => caseFole(attr) == caseFole(cond),
         ),
       );
     }
     return conditionValue.any(
-      (cond) => _caseFole(actualValue) == _caseFole(cond),
+      (cond) => caseFole(actualValue) == caseFole(cond),
     );
   }
 

--- a/lib/src/Evaluator/condition_evaluator.dart
+++ b/lib/src/Evaluator/condition_evaluator.dart
@@ -406,13 +406,17 @@ class GBConditionEvaluator {
           break;
 
         case '\$regex':
-          try {
-            final regEx = RegExp(conditionValue.toString());
-            evaluatedValue = regEx.hasMatch(attributeValue.toString());
-          } catch (e) {
-            evaluatedValue = false;
-          }
-          break;
+          return _evalRegex(conditionValue: conditionValue, attributeValue: attributeValue, isCaseSensitive: true, negate: false);
+
+        case '\$regexi':
+           return _evalRegex(conditionValue: conditionValue, attributeValue: attributeValue, isCaseSensitive: false, negate: false);
+
+        case '\$notRegex':
+          return _evalRegex(conditionValue: conditionValue, attributeValue: attributeValue, isCaseSensitive: true, negate: true);
+
+
+        case '\$notRegexi':
+          return _evalRegex(conditionValue: conditionValue, attributeValue: attributeValue, isCaseSensitive: false, negate: true);
 
         default:
           conditionValue = false;
@@ -428,4 +432,23 @@ class GBConditionEvaluator {
     }
     return conditionValue.contains(actualValue);
   }
+
+  bool _evalRegex({
+    required dynamic conditionValue,
+    required dynamic attributeValue,
+    required bool isCaseSensitive,
+    required bool negate
+    }) {
+
+      if (conditionValue == null || attributeValue == null) {
+        return false;
+      }
+      try {
+        final regex = RegExp(conditionValue.toString(), caseSensitive: isCaseSensitive);
+        final matches = regex.hasMatch(attributeValue.toString());
+        return negate != matches;
+      } catch (_) {
+        return false;
+      }
+    }
 }

--- a/test/common_test/gb_condition_test.dart
+++ b/test/common_test/gb_condition_test.dart
@@ -54,6 +54,64 @@ void main() {
 
       expect(evaluator.evalOperatorCondition("\$nin", "abc", ["abc"], {}), false);
     });
+
+    group('Case-insensitive membership operators', () {
+      final evaluator = GBConditionEvaluator();
+
+      // $ini — basic string case-insensitivity
+      test('\$ini matches string regardless of case', () {
+        expect(evaluator.evalOperatorCondition("\$ini", "Hello", ["hello"], {}), true);
+        expect(evaluator.evalOperatorCondition("\$ini", "WORLD", ["world", "foo"], {}), true);
+        expect(evaluator.evalOperatorCondition("\$ini", "bar", ["BAZ"], {}), false);
+      });
+
+      // $ini — non-string values compared as-is (intentional: no lowercasing)
+      test('\$ini compares non-string values as-is', () {
+        expect(evaluator.evalOperatorCondition("\$ini", 42, [42, "hello"], {}), true);
+        expect(evaluator.evalOperatorCondition("\$ini", 42, [43], {}), false);
+        expect(evaluator.evalOperatorCondition("\$ini", null, [null], {}), true);
+        expect(evaluator.evalOperatorCondition("\$ini", null, ["null"], {}), false);
+        expect(evaluator.evalOperatorCondition("\$ini", true, [true], {}), true);
+        expect(evaluator.evalOperatorCondition("\$ini", false, [true], {}), false);
+      });
+
+      // $ini — mixed-type list attribute
+      test('\$ini with list attribute containing mixed types', () {
+        expect(evaluator.evalOperatorCondition("\$ini", ["Hello", 42], ["hello"], {}), true);
+        expect(evaluator.evalOperatorCondition("\$ini", ["Hello", 42], [42], {}), true);
+        expect(evaluator.evalOperatorCondition("\$ini", ["Hello", 42], ["HELLO", 42], {}), true);
+        expect(evaluator.evalOperatorCondition("\$ini", ["foo", 1], ["bar", 2], {}), false);
+        expect(evaluator.evalOperatorCondition("\$ini", [], ["hello"], {}), false);
+      });
+
+      // $nini
+      test('\$nini returns false when value matches (case-insensitive)', () {
+        expect(evaluator.evalOperatorCondition("\$nini", "Hello", ["hello"], {}), false);
+        expect(evaluator.evalOperatorCondition("\$nini", "xyz", ["abc"], {}), true);
+        expect(evaluator.evalOperatorCondition("\$nini", 42, [42], {}), false);
+        expect(evaluator.evalOperatorCondition("\$nini", 42, [43], {}), true);
+      });
+
+      // $alli — all conditions must match at least one attribute element
+      test('\$alli matches all conditions case-insensitively', () {
+        expect(evaluator.evalOperatorCondition("\$alli", ["Hello", "World"], ["hello", "world"], {}), true);
+        expect(evaluator.evalOperatorCondition("\$alli", ["Hello", "World"], ["HELLO", "WORLD"], {}), true);
+        expect(evaluator.evalOperatorCondition("\$alli", ["Hello"], ["world"], {}), false);
+      });
+
+      // $alli — non-string elements compared as-is
+      test('\$alli with non-string values in attribute list', () {
+        expect(evaluator.evalOperatorCondition("\$alli", ["hello", 42], ["HELLO", 42], {}), true);
+        expect(evaluator.evalOperatorCondition("\$alli", ["hello", 42], ["HELLO", 43], {}), false);
+        expect(evaluator.evalOperatorCondition("\$alli", [null, "foo"], [null, "FOO"], {}), true);
+      });
+
+      // $alli — non-list attributeValue returns false
+      test('\$alli returns false when attribute is not a list', () {
+        expect(evaluator.evalOperatorCondition("\$alli", "hello", ["hello"], {}), false);
+        expect(evaluator.evalOperatorCondition("\$alli", 42, [42], {}), false);
+      });
+    });
   });
 
   test('Test condition fail attribute does not exist', () {

--- a/test/test_cases/test_case.dart
+++ b/test/test_cases/test_case.dart
@@ -759,6 +759,90 @@ const String gbTestCases = r'''
       false
     ],
     [
+      "$regexi - pass (case insensitive match)",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      true
+    ],
+    [
+      "$regexi - pass (uppercase pattern, lowercase value)",
+      {
+        "userAgent": {
+          "$regexi": "(MOBILE|TABLET)"
+        }
+      },
+      {
+        "userAgent": "android mobile browser"
+      },
+      true
+    ],
+    [
+      "$regexi - fail",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      false
+    ],
+    [
+      "$notRegex - pass",
+      {
+        "userAgent": {
+          "$notRegex": "(Mobile|Tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      true
+    ],
+    [
+      "$notRegex - fail",
+      {
+        "userAgent": {
+          "$notRegex": "(Mobile|Tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      false
+    ],
+    [
+      "$notRegexi - pass",
+      {
+        "userAgent": {
+          "$notRegexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      true
+    ],
+    [
+      "$notRegexi - fail",
+      {
+        "userAgent": {
+          "$notRegexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      false
+    ],
+    [
       "$gt/$lt numbers - pass",
       {
         "age": {

--- a/test/test_cases/test_case.dart
+++ b/test/test_cases/test_case.dart
@@ -843,6 +843,90 @@ const String gbTestCases = r'''
       false
     ],
     [
+      "$ini - pass",
+      {
+        "tags": {
+          "$ini": ["A", "B"]
+        }
+      },
+      {
+        "tags": "a"
+      },
+      true
+    ],
+    [
+      "$ini - fail",
+      {
+        "tags": {
+          "$ini": ["a", "b"]
+        }
+      },
+      {
+        "tags": "c"
+      },
+      false
+    ],
+    [
+      "$ini - array pass",
+      {
+        "tags": {
+          "$ini": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["d", "a"]
+      },
+      true
+    ],
+    [
+      "$nini - pass",
+      {
+        "tags": {
+          "$nini": ["A", "B"]
+        }
+      },
+      {
+        "tags": "c"
+      },
+      true
+    ],
+    [
+      "$nini - fail",
+      {
+        "tags": {
+          "$nini": ["A", "B"]
+        }
+      },
+      {
+        "tags": "a"
+      },
+      false
+    ],
+    [
+      "$alli - pass",
+      {
+        "tags": {
+          "$alli": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["a", "b", "c"]
+      },
+      true
+    ],
+    [
+      "$alli - fail",
+      {
+        "tags": {
+          "$alli": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["a", "c"]
+      },
+      false
+    ],
+    [
       "$gt/$lt numbers - pass",
       {
         "age": {


### PR DESCRIPTION
This PR adds support for case-insensitive operators in the condition evaluator.

1. Adds support for case-insensitive regex operators:
- `$regexi`

- `$notRegexi`

- `$notRegex`

2. Adds case-insensitive versions of membership operators:
- `$ini` — case-insensitive version of `$in`

- `$nini` — case-insensitive version of `$nin`

- `$alli` — case-insensitive version of `$all`.