### PR TITLE
fix: preserve base path when constructing API URLs in GBContext

### DIFF
--- a/lib/src/Model/context.dart
+++ b/lib/src/Model/context.dart
@@ -79,21 +79,20 @@ class GBContext {
   ///A URL string that is used for experiment evaluation, as well as forcing feature values.
   String? url;
 
-  String? getFeaturesURL() {
-    if (hostURL != null && apiKey != null) {
-      return Uri.parse(hostURL!)
-          .replace(path: '/api/features/$apiKey')
-          .toString();
-    } else {
-      return null;
-    }
-  }
+  String? getFeaturesURL() => _buildUrl('/api/features/');
 
-  String? getRemoteEvalUrl() {
-    if (hostURL != null && apiKey != null) {
-      return Uri.parse(hostURL!).replace(path: '/api/eval/$apiKey').toString();
-    } else {
-      return null;
+  String? getRemoteEvalUrl() => _buildUrl('/api/eval/');
+
+  String? _buildUrl(String endpoint) {
+    if (hostURL == null || apiKey == null) return null;
+
+    final uri = Uri.parse(hostURL!);
+
+    var basePath = uri.path;
+    while (basePath.endsWith('/')) {
+      basePath = basePath.substring(0, basePath.length - 1);
     }
+
+    return uri.replace(path: '$basePath$endpoint$apiKey').toString();
   }
 }

--- a/test/common_test/gb_context_test.dart
+++ b/test/common_test/gb_context_test.dart
@@ -37,7 +37,10 @@ void main() {
         );
         final url = context.getFeaturesURL();
         expect(url, isNotNull);
-        expect(url, equals('https://example.growthbook.io/api/features/test-api-key-123'));
+        expect(
+            url,
+            equals(
+                'https://example.growthbook.io/api/features/test-api-key-123'));
       });
 
       test('handles hostURL with trailing slash', () {
@@ -49,10 +52,12 @@ void main() {
         );
         final url = context.getFeaturesURL();
         expect(url, isNotNull);
-        expect(url, equals('https://example.growthbook.io/api/features/test-api-key'));
+        expect(url,
+            equals('https://example.growthbook.io/api/features/test-api-key'));
       });
 
-      test('preserves existing path in hostURL when constructing features URL', () {
+      test('preserves existing path in hostURL when constructing features URL',
+          () {
         const hostUrl = 'https://example.growthbook.io/some/path';
         const apiKey = 'test-api-key';
         final context = GBContext(
@@ -61,8 +66,10 @@ void main() {
         );
         final url = context.getFeaturesURL();
         expect(url, isNotNull);
-        // Uri.replace replaces the entire path, so the original path should be replaced
-        expect(url, equals('https://example.growthbook.io/api/features/test-api-key'));
+        expect(
+            url,
+            equals(
+                'https://example.growthbook.io/some/path/api/features/test-api-key'));
       });
     });
 
@@ -100,7 +107,8 @@ void main() {
         );
         final url = context.getRemoteEvalUrl();
         expect(url, isNotNull);
-        expect(url, equals('https://example.growthbook.io/api/eval/test-api-key-456'));
+        expect(url,
+            equals('https://example.growthbook.io/api/eval/test-api-key-456'));
       });
 
       test('handles hostURL with trailing slash', () {
@@ -112,7 +120,8 @@ void main() {
         );
         final url = context.getRemoteEvalUrl();
         expect(url, isNotNull);
-        expect(url, equals('https://example.growthbook.io/api/eval/test-api-key'));
+        expect(
+            url, equals('https://example.growthbook.io/api/eval/test-api-key'));
       });
 
       test('preserves existing path in hostURL when constructing eval URL', () {
@@ -124,8 +133,22 @@ void main() {
         );
         final url = context.getRemoteEvalUrl();
         expect(url, isNotNull);
-        // Uri.replace replaces the entire path, so the original path should be replaced
-        expect(url, equals('https://example.growthbook.io/api/eval/test-api-key'));
+        expect(
+            url,
+            equals(
+                'https://example.growthbook.io/some/path/api/eval/test-api-key'));
+      });
+
+      test('handles hostURL with multiple trailing slashes', () {
+        final context = GBContext(
+          hostURL: 'https://example.growthbook.io/some/path//',
+          apiKey: 'test-api-key',
+        );
+        expect(
+          context.getFeaturesURL(),
+          equals(
+              'https://example.growthbook.io/some/path/api/features/test-api-key'),
+        );
       });
     });
   });


### PR DESCRIPTION
## Summary
- Fixes a bug where `getFeaturesURL` and `getRemoteEvalUrl` would drop any sub-path from `hostURL` (e.g. `https://something.com/some-other-path` would produce `https://something.com/api/...` instead of `https://something.com/some-other-path/api/...`)
- Extracted shared logic into a private `_buildUrl` helper to eliminate duplication
- Added trailing slash normalization to handle multiple consecutive slashes in `hostURL`