### PR TITLE
test: increase unit test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ app.*.map.json
 
 # Generated files
 # **/*.g.dart
+
+# Test coverage
+coverage/

--- a/test/common_test/caching_manager_extra_test.dart
+++ b/test/common_test/caching_manager_extra_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/src/Cache/caching_manager.dart';
+
+void main() {
+  group('CachingManager — additional coverage', () {
+    final manager = CachingManager();
+
+    tearDown(() async {
+      await manager.clearCache();
+    });
+
+    // -------------------------------------------------------------------------
+    // getData — alias for getContent
+    // -------------------------------------------------------------------------
+    group('getData', () {
+      test('returns null when file does not exist', () async {
+        final result = await manager.getData(fileName: 'nonexistent-file');
+        expect(result, isNull);
+      });
+
+      test('returns content that was previously saved', () async {
+        const fileName = 'test-get-data';
+        final content = Uint8List.fromList(utf8.encode('{"test":1}'));
+        await manager.saveContent(fileName: fileName, content: content);
+
+        final result = await manager.getData(fileName: fileName);
+        expect(result, isNotNull);
+        expect(utf8.decode(result!), '{"test":1}');
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // removeContent
+    // -------------------------------------------------------------------------
+    group('removeContent', () {
+      test('removes an existing file so getContent returns null', () async {
+        const fileName = 'test-remove-existing';
+        final content = Uint8List.fromList(utf8.encode('data'));
+        await manager.saveContent(fileName: fileName, content: content);
+
+        // Confirm it exists first
+        expect(await manager.getContent(fileName: fileName), isNotNull);
+
+        await manager.removeContent(fileName: fileName);
+
+        expect(await manager.getContent(fileName: fileName), isNull);
+      });
+
+      test('does not throw when removing a nonexistent file', () async {
+        await expectLater(
+          manager.removeContent(fileName: 'does-not-exist'),
+          completes,
+        );
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // clearCache — already-empty directory path
+    // -------------------------------------------------------------------------
+    group('clearCache', () {
+      test('does not throw when cache is already empty', () async {
+        await manager.clearCache(); // ensure empty
+        await expectLater(manager.clearCache(), completes);
+      });
+    });
+  });
+}

--- a/test/common_test/crypto_utils_test.dart
+++ b/test/common_test/crypto_utils_test.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/src/Utils/crypto.dart';
+import 'package:growthbook_sdk_flutter/src/Utils/decrytion_utils.dart';
+
+// Valid 16-byte key and IV (base64-encoded)
+const _validKeyB64 = 'Ns04T5n9+59rl2x3SlNHtQ=='; // 16 bytes
+final _validKey = base64Decode(_validKeyB64);
+final _validIv = Uint8List(16); // 16 zero bytes
+
+void main() {
+  // -------------------------------------------------------------------------
+  // DecryptionUtils.keyFromSecret
+  // -------------------------------------------------------------------------
+  group('DecryptionUtils.keyFromSecret', () {
+    test('decodes a base64 key into bytes', () {
+      final result = DecryptionUtils.keyFromSecret(_validKeyB64);
+      expect(result, isA<Uint8List>());
+      expect(result.length, 16);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DecryptionException constructor
+  // -------------------------------------------------------------------------
+  group('DecryptionException', () {
+    test('stores the error message', () {
+      final e = DecryptionException('something went wrong');
+      expect(e.errorMessage, 'something went wrong');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // CryptoError constructors
+  // -------------------------------------------------------------------------
+  group('CryptoError', () {
+    test('default constructor stores code', () {
+      final e = CryptoError('ERR_001');
+      expect(e.code, 'ERR_001');
+    });
+
+    test('fromString constructor stores code', () {
+      final e = CryptoError.fromString('ERR_002');
+      expect(e.code, 'ERR_002');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Crypto.encrypt — invalid size guard
+  // -------------------------------------------------------------------------
+  group('Crypto.encrypt', () {
+    test('throws CryptoError when key size is invalid', () {
+      final crypto = Crypto();
+      final badKey = Uint8List(5); // not 16/24/32 bytes
+      expect(
+        () => crypto.encrypt(badKey, _validIv, Uint8List(16)),
+        throwsA(isA<CryptoError>()),
+      );
+    });
+
+    test('throws CryptoError when IV size is invalid', () {
+      final crypto = Crypto();
+      final badIv = Uint8List(8); // not 16 bytes
+      expect(
+        () => crypto.encrypt(_validKey, badIv, Uint8List(16)),
+        throwsA(isA<CryptoError>()),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Crypto.decrypt — invalid size guard
+  // -------------------------------------------------------------------------
+  group('Crypto.decrypt', () {
+    test('throws CryptoError when cypherText length is not a multiple of 16', () {
+      final crypto = Crypto();
+      final badCipher = Uint8List(15); // not multiple of 16
+      expect(
+        () => crypto.decrypt(_validKey, _validIv, badCipher),
+        throwsA(isA<CryptoError>()),
+      );
+    });
+
+    test('throws CryptoError when key size is invalid', () {
+      final crypto = Crypto();
+      final badKey = Uint8List(5);
+      expect(
+        () => crypto.decrypt(badKey, _validIv, Uint8List(16)),
+        throwsA(isA<CryptoError>()),
+      );
+    });
+  });
+}

--- a/test/common_test/dio_client_test.dart
+++ b/test/common_test/dio_client_test.dart
@@ -1,0 +1,358 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/src/Network/network.dart';
+
+// ---------------------------------------------------------------------------
+// Minimal mock HttpClientAdapter
+// ---------------------------------------------------------------------------
+typedef _AdapterHandler = Future<ResponseBody> Function(RequestOptions options);
+
+class _MockAdapter implements HttpClientAdapter {
+  _MockAdapter(this._handler);
+  final _AdapterHandler _handler;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestBodyBytes,
+    Future<void>? cancelFuture,
+  ) =>
+      _handler(options);
+
+  @override
+  void close({bool force = false}) {}
+}
+
+// Stateful mock that succeeds once then throws to break SSE reconnect loop.
+class _OnceThenErrorAdapter implements HttpClientAdapter {
+  int _calls = 0;
+  final ResponseBody firstResponse;
+
+  _OnceThenErrorAdapter(this.firstResponse);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestBodyBytes,
+    Future<void>? cancelFuture,
+  ) async {
+    _calls++;
+    if (_calls == 1) return firstResponse;
+    throw DioException(
+      requestOptions: options,
+      type: DioExceptionType.connectionError,
+      message: 'reconnect cancelled by test',
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+DioClient _clientWith(_AdapterHandler handler) {
+  final c = DioClient();
+  c.client.httpClientAdapter = _MockAdapter(handler);
+  return c;
+}
+
+void main() {
+  group('DioClient', () {
+    // -----------------------------------------------------------------------
+    // Pure-logic / trivial
+    // -----------------------------------------------------------------------
+    group('shouldReconnect', () {
+      test('returns true for 2xx status codes', () {
+        final c = DioClient();
+        expect(c.shouldReconnect(200), isTrue);
+        expect(c.shouldReconnect(201), isTrue);
+        expect(c.shouldReconnect(299), isTrue);
+      });
+
+      test('returns false for status codes outside 2xx', () {
+        final c = DioClient();
+        expect(c.shouldReconnect(300), isFalse);
+        expect(c.shouldReconnect(400), isFalse);
+        expect(c.shouldReconnect(500), isFalse);
+        expect(c.shouldReconnect(199), isFalse);
+      });
+    });
+
+    test('client getter returns the Dio instance', () {
+      final c = DioClient();
+      expect(c.client, isA<Dio>());
+    });
+
+    // -----------------------------------------------------------------------
+    // consumeGetRequest
+    // -----------------------------------------------------------------------
+    group('consumeGetRequest', () {
+      test('calls onSuccess with decoded map on 200 JSON response', () async {
+        final c = _clientWith((_) async =>
+            ResponseBody.fromString('{"status":200,"features":{}}', 200,
+                headers: {'content-type': ['application/json']}));
+
+        Map<String, dynamic>? received;
+        await c.consumeGetRequest(
+          'http://test.com/data',
+          (data) => received = data,
+          (e, s) => fail('onError should not be called: $e'),
+        );
+
+        expect(received, isNotNull);
+        expect(received!['status'], 200);
+      });
+
+      test('calls onSuccess when response.data is a plain JSON string', () async {
+        final c = DioClient();
+        c.client.options.responseType = ResponseType.plain;
+        c.client.httpClientAdapter = _MockAdapter((_) async =>
+            ResponseBody.fromString('{"key":"value"}', 200));
+
+        Map<String, dynamic>? received;
+        await c.consumeGetRequest(
+          'http://test.com/data',
+          (data) => received = data,
+          (e, s) => fail('onError should not be called: $e'),
+        );
+
+        expect(received, isNotNull);
+        expect(received!['key'], 'value');
+      });
+
+      test('calls onError when string response is not valid JSON', () async {
+        final c = DioClient();
+        c.client.options.responseType = ResponseType.plain;
+        c.client.httpClientAdapter =
+            _MockAdapter((_) async => ResponseBody.fromString('not json', 200));
+
+        Object? capturedError;
+        await c.consumeGetRequest(
+          'http://test.com/data',
+          (data) => fail('onSuccess should not be called'),
+          (e, s) => capturedError = e,
+        );
+
+        expect(capturedError, isNotNull);
+      });
+
+      test('calls onError when response format is unexpected', () async {
+        // A JSON array is neither Map nor String → unexpected format
+        final c = _clientWith((_) async =>
+            ResponseBody.fromString('[1,2,3]', 200,
+                headers: {'content-type': ['application/json']}));
+
+        Object? capturedError;
+        await c.consumeGetRequest(
+          'http://test.com/data',
+          (data) => fail('onSuccess should not be called'),
+          (e, s) => capturedError = e,
+        );
+
+        expect(capturedError, isNotNull);
+      });
+
+      test('returns without calling callbacks on 304 Not Modified', () async {
+        final c = DioClient();
+        c.client.httpClientAdapter = _MockAdapter((_) async =>
+            ResponseBody.fromString('', 304));
+        c.client.options.validateStatus = (s) =>
+            s != null && (s >= 200 && s < 300 || s == 304);
+
+        bool successCalled = false;
+        bool errorCalled = false;
+
+        await c.consumeGetRequest(
+          'http://test.com/data',
+          (_) => successCalled = true,
+          (e, s) => errorCalled = true,
+        );
+
+        expect(successCalled, isFalse);
+        expect(errorCalled, isFalse);
+      });
+
+      test('stores etag from features URL response', () async {
+        const featuresUrl = 'http://test.com/api/features/mykey';
+
+        final c = _clientWith((_) async => ResponseBody.fromString(
+              '{"features":{}}',
+              200,
+              headers: {
+                'content-type': ['application/json'],
+                'etag': ['"abc123"'],
+              },
+            ));
+
+        RequestOptions? secondRequestOptions;
+        int callCount = 0;
+        c.client.httpClientAdapter = _MockAdapter((options) async {
+          callCount++;
+          if (callCount == 1) {
+            return ResponseBody.fromString('{"features":{}}', 200,
+                headers: {
+                  'content-type': ['application/json'],
+                  'etag': ['"abc123"'],
+                });
+          }
+          secondRequestOptions = options;
+          return ResponseBody.fromString('{"features":{}}', 200,
+              headers: {'content-type': ['application/json']});
+        });
+
+        await c.consumeGetRequest(featuresUrl, (_) {}, (e, s) {});
+        await c.consumeGetRequest(featuresUrl, (_) {}, (e, s) {});
+
+        expect(secondRequestOptions?.headers['If-None-Match'], '"abc123"');
+      });
+
+      test('does not add etag headers for non-features URLs', () async {
+        const nonFeaturesUrl = 'http://test.com/other/path';
+
+        RequestOptions? capturedOptions;
+        final c = _clientWith((options) async {
+          capturedOptions = options;
+          return ResponseBody.fromString('{"data":1}', 200,
+              headers: {'content-type': ['application/json']});
+        });
+
+        await c.consumeGetRequest(nonFeaturesUrl, (_) {}, (e, s) {});
+
+        expect(capturedOptions?.headers.containsKey('If-None-Match'), isFalse);
+        expect(capturedOptions?.headers.containsKey('Cache-Control'), isFalse);
+      });
+
+      test('calls onError on DioException', () async {
+        final c = DioClient();
+        c.client.httpClientAdapter = _MockAdapter((options) async {
+          throw DioException(
+            requestOptions: options,
+            type: DioExceptionType.connectionError,
+          );
+        });
+
+        Object? capturedError;
+        await c.consumeGetRequest(
+          'http://test.com/data',
+          (_) => fail('onSuccess should not be called'),
+          (e, s) => capturedError = e,
+        );
+
+        expect(capturedError, isA<DioException>());
+      });
+
+      test('calls onError on unexpected exception', () async {
+        final c = DioClient();
+        c.client.httpClientAdapter =
+            _MockAdapter((_) async => throw Exception('boom'));
+
+        Object? capturedError;
+        await c.consumeGetRequest(
+          'http://test.com/data',
+          (_) => fail('onSuccess should not be called'),
+          (e, s) => capturedError = e,
+        );
+
+        expect(capturedError, isNotNull);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // consumePostRequest
+    // -----------------------------------------------------------------------
+    group('consumePostRequest', () {
+      test('calls onSuccess with decoded response on success', () async {
+        final c = _clientWith((_) async => ResponseBody.fromString(
+              '{"result":"ok"}',
+              200,
+              headers: {'content-type': ['application/json']},
+            ));
+
+        Map<String, dynamic>? received;
+        await c.consumePostRequest(
+          'http://test.com/api',
+          {'key': 'value'},
+          (data) => received = data,
+          (e, s) => fail('onError should not be called: $e'),
+        );
+
+        expect(received, isNotNull);
+        expect(received!['result'], 'ok');
+      });
+
+      test('calls onError when POST request throws', () async {
+        final c = DioClient();
+        c.client.httpClientAdapter = _MockAdapter((options) async {
+          throw DioException(
+            requestOptions: options,
+            type: DioExceptionType.connectionError,
+          );
+        });
+
+        Object? capturedError;
+        await c.consumePostRequest(
+          'http://test.com/api',
+          {},
+          (_) => fail('onSuccess should not be called'),
+          (e, s) => capturedError = e,
+        );
+
+        expect(capturedError, isA<DioException>());
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // consumeSseConnections / listenAndRetry
+    // -----------------------------------------------------------------------
+    group('consumeSseConnections', () {
+      test('delivers SSE event to onSuccess callback', () async {
+        const ssePayload =
+            'id: 1\nevent: features\ndata: {"status":200,"features":{}}\n\n';
+
+        final c = DioClient();
+        c.client.httpClientAdapter = _OnceThenErrorAdapter(
+          ResponseBody.fromString(ssePayload, 200,
+              headers: {'content-type': ['text/event-stream']}),
+        );
+
+        final completer = Completer<Map<String, dynamic>>();
+        await c.consumeSseConnections(
+          'http://test.com/sse',
+          (data) {
+            if (!completer.isCompleted) completer.complete(data);
+          },
+          (e, s) {
+            // reconnect failure is expected; ignore after onSuccess
+          },
+        );
+
+        final result = await completer.future;
+        expect(result, isNotNull);
+      });
+
+      test('calls onError when SSE connection fails immediately', () async {
+        final c = DioClient();
+        c.client.httpClientAdapter = _MockAdapter((options) async {
+          throw DioException(
+            requestOptions: options,
+            type: DioExceptionType.connectionError,
+          );
+        });
+
+        Object? capturedError;
+        await c.consumeSseConnections(
+          'http://test.com/sse',
+          (_) {},
+          (e, s) => capturedError = e,
+        );
+
+        expect(capturedError, isNotNull);
+      });
+    });
+  });
+}

--- a/test/common_test/experiment_test.dart
+++ b/test/common_test/experiment_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
+
+void main() {
+  group('GBExperiment', () {
+    // -------------------------------------------------------------------------
+    // deactivated getter
+    // -------------------------------------------------------------------------
+    group('deactivated', () {
+      test('returns false when active is true', () {
+        final exp = GBExperiment(key: 'exp', active: true);
+        expect(exp.deactivated, isFalse);
+      });
+
+      test('returns true when active is false', () {
+        final exp = GBExperiment(key: 'exp', active: false);
+        expect(exp.deactivated, isTrue);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // fromJson / toJson round-trip
+    // -------------------------------------------------------------------------
+    group('toJson / fromJson', () {
+      test('round-trips a minimal experiment', () {
+        final exp = GBExperiment(key: 'my-exp');
+        final json = exp.toJson();
+        expect(json['key'], 'my-exp');
+
+        final restored = GBExperiment.fromJson(json);
+        expect(restored.key, 'my-exp');
+        expect(restored.active, isTrue);
+      });
+
+      test('round-trips all scalar fields', () {
+        final exp = GBExperiment(
+          key: 'full-exp',
+          active: false,
+          coverage: 0.5,
+          force: 1,
+          hashVersion: 2,
+          disableStickyBucketing: true,
+          bucketVersion: 3,
+          minBucketVersion: 1,
+          seed: 'abc',
+          name: 'Full experiment',
+          phase: '1',
+          hashAttribute: 'id',
+          fallbackAttribute: 'device',
+          weights: [0.5, 0.5],
+        );
+
+        final json = exp.toJson();
+        final restored = GBExperiment.fromJson(json);
+
+        expect(restored.key, 'full-exp');
+        expect(restored.active, isFalse);
+        expect(restored.coverage, 0.5);
+        expect(restored.force, 1);
+        expect(restored.hashVersion, 2);
+        expect(restored.disableStickyBucketing, isTrue);
+        expect(restored.bucketVersion, 3);
+        expect(restored.minBucketVersion, 1);
+        expect(restored.seed, 'abc');
+        expect(restored.name, 'Full experiment');
+        expect(restored.phase, '1');
+        expect(restored.hashAttribute, 'id');
+        expect(restored.fallbackAttribute, 'device');
+        expect(restored.weights, [0.5, 0.5]);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // toString
+    // -------------------------------------------------------------------------
+    group('toString', () {
+      test('contains key fields', () {
+        final exp = GBExperiment(
+          key: 'exp-str',
+          active: true,
+          coverage: 0.8,
+          seed: 'seed-val',
+          name: 'My Exp',
+          phase: '2',
+          hashAttribute: 'user',
+          fallbackAttribute: 'device',
+          disableStickyBucketing: false,
+        );
+        final str = exp.toString();
+
+        expect(str, contains('true'));
+        expect(str, contains('0.8'));
+        expect(str, contains('seed-val'));
+        expect(str, contains('My Exp'));
+        expect(str, contains('2'));
+        expect(str, contains('user'));
+        expect(str, contains('device'));
+        expect(str, contains('false'));
+      });
+
+      test('does not throw with all-null optional fields', () {
+        final exp = GBExperiment(key: 'min');
+        expect(() => exp.toString(), returnsNormally);
+      });
+    });
+  });
+}

--- a/test/common_test/features_model_test.dart
+++ b/test/common_test/features_model_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
+
+void main() {
+  // -------------------------------------------------------------------------
+  // GBFeatureRule — toString
+  // -------------------------------------------------------------------------
+  group('GBFeatureRule', () {
+    group('toString', () {
+      test('does not throw with all-null optional fields', () {
+        final rule = GBFeatureRule();
+        expect(() => rule.toString(), returnsNormally);
+      });
+
+      test('contains populated field values', () {
+        final rule = GBFeatureRule(
+          id: 'rule-1',
+          coverage: 0.6,
+          force: 'value-a',
+          key: 'exp-key',
+          hashAttribute: 'id',
+          fallbackAttribute: 'device',
+          hashVersion: 2,
+          disableStickyBucketing: true,
+          bucketVersion: 1,
+          minBucketVersion: 0,
+          seed: 'my-seed',
+          name: 'My Rule',
+          phase: '3',
+        );
+        final str = rule.toString();
+
+        expect(str, contains('rule-1'));
+        expect(str, contains('0.6'));
+        expect(str, contains('value-a'));
+        expect(str, contains('exp-key'));
+        expect(str, contains('id'));
+        expect(str, contains('device'));
+        expect(str, contains('2'));
+        expect(str, contains('true'));
+        expect(str, contains('my-seed'));
+        expect(str, contains('My Rule'));
+        expect(str, contains('3'));
+      });
+    });
+
+    group('toJson / fromJson', () {
+      test('round-trips a minimal rule', () {
+        final rule = GBFeatureRule(id: 'r1', coverage: 0.5);
+        final json = rule.toJson();
+        final restored = GBFeatureRule.fromJson(json);
+        expect(restored.id, 'r1');
+        expect(restored.coverage, 0.5);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GBFeatureResult — fromJson / toJson
+  // -------------------------------------------------------------------------
+  group('GBFeatureResult', () {
+    group('toJson / fromJson', () {
+      test('round-trips a minimal result', () {
+        final result = GBFeatureResult(
+          value: 'hello',
+          on: true,
+          off: false,
+          source: GBFeatureSource.force,
+        );
+        final json = result.toJson();
+        expect(json['value'], 'hello');
+        expect(json['on'], isTrue);
+
+        final restored = GBFeatureResult.fromJson(json);
+        expect(restored.value, 'hello');
+        expect(restored.on, isTrue);
+        expect(restored.off, isFalse);
+        expect(restored.source, GBFeatureSource.force);
+      });
+
+      test('round-trips a result with default values', () {
+        final result = GBFeatureResult();
+        final json = result.toJson();
+        final restored = GBFeatureResult.fromJson(json);
+        expect(restored.on, isFalse);
+        expect(restored.off, isTrue);
+        expect(restored.value, isNull);
+      });
+    });
+  });
+}

--- a/test/common_test/features_view_model_extra_test.dart
+++ b/test/common_test/features_view_model_extra_test.dart
@@ -1,0 +1,270 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
+import 'package:growthbook_sdk_flutter/src/Cache/caching_manager.dart';
+
+import '../mocks/network_mock.dart';
+import '../mocks/network_view_model_mock.dart';
+
+// Delegate that throws on featuresAPIModelSuccessfully to exercise
+// the catch block inside prepareFeaturesData.
+class _ThrowingDelegate extends DataSourceMock {
+  @override
+  void featuresAPIModelSuccessfully(FeaturedDataModel model) {
+    throw Exception('deliberate error for testing');
+  }
+}
+
+void main() {
+  group('FeatureViewModel — additional coverage', () {
+    const testHostURL = '<HOST URL>';
+    const testApiKey = '<SOME KEY>';
+    const attr = <String, String>{};
+
+    late GBContext context;
+    late DataSourceMock delegate;
+
+    // Encrypted features test vectors (reused from sdk_builder_test)
+    const validEncryptedFeatures =
+        'vMSg2Bj/IurObDsWVmvkUg==.L6qtQkIzKDoE2Dix6IAKDcVel8PHUnzJ7JjmLjFZFQDqidRIoCxKmvxvUj2kTuHFTQ3/NJ3D6XhxhXXv2+dsXpw5woQf0eAgqrcxHrbtFORs18tRXRZza7zqgzwvcznx';
+    const validEncryptionKey = 'Ns04T5n9+59rl2x3SlNHtQ==';
+    // Wrong key (valid base64 length, decryption returns null)
+    const wrongEncryptionKey = 'AAAAAAAAAAAAAAAAAAAAAA==';
+    // Invalid base64 — causes exception inside _decryptString before inner try-catch
+    const invalidBase64Encrypted = '!bad-base64!.!more-bad!';
+
+    FeatureViewModel buildViewModel({
+      String encryptionKey = '',
+      bool networkError = false,
+      FeaturesFlowDelegate? customDelegate,
+    }) {
+      return FeatureViewModel(
+        encryptionKey: encryptionKey,
+        delegate: customDelegate ?? delegate,
+        source: FeatureDataSource(
+          client: MockNetworkClient(error: networkError),
+          context: context,
+        ),
+      );
+    }
+
+    setUp(() {
+      context = GBContext(
+        apiKey: testApiKey,
+        hostURL: testHostURL,
+        attributes: attr,
+        enabled: true,
+        forcedVariation: {},
+        qaMode: false,
+        trackingCallBack: (_) {},
+      );
+      delegate = DataSourceMock();
+    });
+
+    tearDown(() async {
+      await CachingManager().clearCache();
+    });
+
+    // -------------------------------------------------------------------------
+    // connectBackgroundSync
+    // -------------------------------------------------------------------------
+    group('connectBackgroundSync', () {
+      test('fetches features via SSE and calls success delegate', () async {
+        final vm = buildViewModel();
+        await vm.connectBackgroundSync();
+        expect(delegate.isSuccess, isTrue);
+      });
+
+      test('reports error when SSE connection fails', () async {
+        final vm = buildViewModel(networkError: true);
+        await vm.connectBackgroundSync();
+        expect(delegate.isError, isTrue);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // prepareFeaturesData
+    // -------------------------------------------------------------------------
+    group('prepareFeaturesData', () {
+      test('returns false when both features and encryptedFeatures are null', () {
+        final vm = buildViewModel();
+        final data = FeaturedDataModel(
+          features: null,
+          encryptedFeatures: null,
+        );
+        expect(vm.prepareFeaturesData(data), isFalse);
+      });
+
+      test('catch block calls handleException when delegate throws', () {
+        final throwingDelegate = _ThrowingDelegate();
+        final vm = buildViewModel(customDelegate: throwingDelegate);
+        final data = FeaturedDataModel(
+          features: {'flag': GBFeature(defaultValue: true)},
+          encryptedFeatures: null,
+        );
+        // Should not throw — exception is caught inside prepareFeaturesData
+        expect(() => vm.prepareFeaturesData(data), returnsNormally);
+        expect(throwingDelegate.isError, isTrue);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // handleValidFeatures — saved groups
+    // -------------------------------------------------------------------------
+    group('handleValidFeatures with savedGroups', () {
+      test('calls savedGroupsFetchedSuccessfully when savedGroups is present', () {
+        final vm = buildViewModel();
+        final data = FeaturedDataModel(
+          features: {'flag': GBFeature(defaultValue: true)},
+          encryptedFeatures: null,
+          savedGroups: {'admins': ['user-1', 'user-2']},
+        );
+        vm.handleValidFeatures(data);
+        expect(delegate.isSuccess, isTrue);
+      });
+
+      test('skips savedGroups when null', () {
+        final vm = buildViewModel();
+        final data = FeaturedDataModel(
+          features: {'flag': GBFeature(defaultValue: false)},
+          encryptedFeatures: null,
+          savedGroups: null,
+        );
+        expect(() => vm.handleValidFeatures(data), returnsNormally);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // handleValidFeatures — encrypted path
+    // -------------------------------------------------------------------------
+    group('handleValidFeatures encrypted path', () {
+      test('delegates to handleEncryptedFeatures when encryptedFeatures is set', () {
+        final vm = buildViewModel(encryptionKey: validEncryptionKey);
+        final data = FeaturedDataModel(
+          features: null,
+          encryptedFeatures: validEncryptedFeatures,
+        );
+        final result = vm.handleValidFeatures(data);
+        expect(result, isTrue);
+        expect(delegate.isSuccess, isTrue);
+      });
+
+      test('returns false when encryptedFeatures decryption fails', () {
+        final vm = buildViewModel(encryptionKey: wrongEncryptionKey);
+        final data = FeaturedDataModel(
+          features: null,
+          encryptedFeatures: validEncryptedFeatures,
+        );
+        expect(vm.handleValidFeatures(data), isFalse);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // handleEncryptedFeatures
+    // -------------------------------------------------------------------------
+    group('handleEncryptedFeatures', () {
+      test('returns false for empty encrypted string', () {
+        final vm = buildViewModel(encryptionKey: validEncryptionKey);
+        expect(vm.handleEncryptedFeatures(''), isFalse);
+      });
+
+      test('returns false when encryptionKey is empty', () {
+        final vm = buildViewModel();
+        expect(vm.handleEncryptedFeatures(validEncryptedFeatures), isFalse);
+      });
+
+      test('returns true and notifies delegate on successful decryption', () {
+        final vm = buildViewModel(encryptionKey: validEncryptionKey);
+        expect(vm.handleEncryptedFeatures(validEncryptedFeatures), isTrue);
+        expect(delegate.isSuccess, isTrue);
+      });
+
+      test('returns false when decryption produces null (wrong key)', () {
+        final vm = buildViewModel(encryptionKey: wrongEncryptionKey);
+        expect(vm.handleEncryptedFeatures(validEncryptedFeatures), isFalse);
+      });
+
+      test('returns false and calls featuresFetchFailed on exception', () {
+        final vm = buildViewModel(encryptionKey: validEncryptionKey);
+        // Invalid base64 causes FormatException outside _decryptString inner try-catch
+        expect(vm.handleEncryptedFeatures(invalidBase64Encrypted), isFalse);
+        expect(delegate.isError, isTrue);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // handleEncryptedSavedGroups
+    // -------------------------------------------------------------------------
+    group('handleEncryptedSavedGroups', () {
+      test('returns false for empty encrypted string', () {
+        final vm = buildViewModel(encryptionKey: validEncryptionKey);
+        expect(vm.handleEncryptedSavedGroups(''), isFalse);
+      });
+
+      test('returns false when encryptionKey is empty', () {
+        final vm = buildViewModel();
+        expect(vm.handleEncryptedSavedGroups(validEncryptedFeatures), isFalse);
+      });
+
+      test('returns true and notifies delegate on successful decryption', () {
+        final vm = buildViewModel(encryptionKey: validEncryptionKey);
+        // validEncryptedFeatures decrypts to a Map<String, dynamic> — valid savedGroups
+        expect(vm.handleEncryptedSavedGroups(validEncryptedFeatures), isTrue);
+        expect(delegate.isSuccess, isTrue);
+      });
+
+      test('returns false when decryption produces null (wrong key)', () {
+        final vm = buildViewModel(encryptionKey: wrongEncryptionKey);
+        expect(vm.handleEncryptedSavedGroups(validEncryptedFeatures), isFalse);
+      });
+
+      test('returns false and calls savedGroupsFetchFailed on exception', () {
+        final vm = buildViewModel(encryptionKey: validEncryptionKey);
+        expect(vm.handleEncryptedSavedGroups(invalidBase64Encrypted), isFalse);
+        expect(delegate.isError, isTrue);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // cacheFeatures
+    // -------------------------------------------------------------------------
+    group('cacheFeatures', () {
+      test('stores features in cache without throwing', () {
+        final vm = buildViewModel();
+        final data = FeaturedDataModel(
+          features: {'flag': GBFeature(defaultValue: true)},
+          encryptedFeatures: null,
+        );
+        expect(() => vm.cacheFeatures(data), returnsNormally);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // _fetchCachedFeatures with non-empty encryptionKey (line 179)
+    // -------------------------------------------------------------------------
+    group('fetchFeatures with pre-populated cache and encryptionKey', () {
+      test('reads cached features via GBFeaturesConverter when encryptionKey is set', () async {
+        // Pre-populate cache with mock features JSON
+        final cacheContent = Uint8List.fromList(utf8.encode(MockResponse.successResponse));
+        CachingManager().putData(
+          fileName: Constant.featureCache,
+          content: cacheContent,
+        );
+
+        final vm = FeatureViewModel(
+          encryptionKey: '3tfeoyW0wlo47bDnbWDkxg==',
+          delegate: delegate,
+          source: FeatureDataSource(
+            client: const MockNetworkClient(),
+            context: context,
+          ),
+        );
+
+        await vm.fetchFeatures(context.getFeaturesURL());
+        expect(delegate.isSuccess, isTrue);
+      });
+    });
+  });
+}

--- a/test/common_test/gb_sdk_attributes_test.dart
+++ b/test/common_test/gb_sdk_attributes_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
+import 'package:growthbook_sdk_flutter/src/Cache/caching_manager.dart';
+
+import '../mocks/network_mock.dart';
+
+void main() {
+  group('GrowthBookSDK — attribute & variation management', () {
+    const testApiKey = '<API_KEY>';
+    const testHostURL = 'https://example.growthbook.io';
+    const client = MockNetworkClient();
+    final cachingManager = CachingManager();
+
+    Future<GrowthBookSDK> buildSdk({Map<String, dynamic>? attributes}) async {
+      return GBSDKBuilderApp(
+        apiKey: testApiKey,
+        hostURL: testHostURL,
+        attributes: attributes ?? {'id': 'user-1'},
+        client: client,
+        growthBookTrackingCallBack: (_) {},
+        backgroundSync: false,
+      ).initialize();
+    }
+
+    tearDown(() {
+      cachingManager.clearCache();
+    });
+
+    // -------------------------------------------------------------------------
+    // setAttributes
+    // -------------------------------------------------------------------------
+    group('setAttributes', () {
+      test('updates context.attributes', () async {
+        final sdk = await buildSdk(attributes: {'id': 'user-1'});
+        sdk.setAttributes({'id': 'user-2', 'country': 'UA'});
+        expect(sdk.context.attributes, {'id': 'user-2', 'country': 'UA'});
+      });
+
+      test('replaces previous attributes entirely', () async {
+        final sdk = await buildSdk(attributes: {'id': 'user-1', 'plan': 'free'});
+        sdk.setAttributes({'id': 'user-2'});
+        expect(sdk.context.attributes?.containsKey('plan'), isFalse);
+      });
+
+      test('new attributes affect experiment bucketing', () async {
+        final sdk = await buildSdk(attributes: {'id': 'user-1'});
+
+        // Experiment with condition — only users with role == 'tester' pass
+        final experiment = GBExperiment(
+          key: 'attr-exp',
+          variations: [0, 1],
+          condition: {'role': 'tester'},
+        );
+
+        final before = sdk.run(experiment);
+        expect(before.inExperiment, isFalse);
+
+        sdk.setAttributes({'id': 'user-1', 'role': 'tester'});
+        final after = sdk.run(experiment);
+        expect(after.inExperiment, isTrue);
+      });
+
+      test('accepts empty attributes map', () async {
+        final sdk = await buildSdk(attributes: {'id': 'user-1'});
+        sdk.setAttributes({});
+        expect(sdk.context.attributes, isEmpty);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // setAttributeOverrides
+    // -------------------------------------------------------------------------
+    group('setAttributeOverrides', () {
+      test('stores decoded overrides accessible via getter', () async {
+        final sdk = await buildSdk();
+        sdk.setAttributeOverrides('{"premium": true, "country": "UA"}');
+        expect(sdk.attributeOverrides['premium'], true);
+        expect(sdk.attributeOverrides['country'], 'UA');
+      });
+
+      test('attributeOverrides getter returns empty map initially', () async {
+        final sdk = await buildSdk();
+        expect(sdk.attributeOverrides, isEmpty);
+      });
+
+      test('replaces previous overrides on subsequent calls', () async {
+        final sdk = await buildSdk();
+        sdk.setAttributeOverrides('{"key": "first"}');
+        sdk.setAttributeOverrides('{"key": "second"}');
+        expect(sdk.attributeOverrides['key'], 'second');
+      });
+
+      test('accepts empty JSON object', () async {
+        final sdk = await buildSdk();
+        sdk.setAttributeOverrides('{}');
+        expect(sdk.attributeOverrides, isEmpty);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // setForcedVariations
+    // -------------------------------------------------------------------------
+    group('setForcedVariations', () {
+      test('updates context.forcedVariation', () async {
+        final sdk = await buildSdk();
+        sdk.setForcedVariations({'exp-key': 1});
+        expect(sdk.context.forcedVariation?['exp-key'], 1);
+      });
+
+      test('forces specific variation index when running experiment', () async {
+        final sdk = await buildSdk(attributes: {'id': 'user-1'});
+        sdk.setForcedVariations({'forced-exp': 2});
+
+        final result = sdk.run(GBExperiment(
+          key: 'forced-exp',
+          variations: [0, 1, 2],
+        ));
+
+        expect(result.variationID, 2);
+      });
+
+      test('overrides previous forced variations', () async {
+        final sdk = await buildSdk(attributes: {'id': 'user-1'});
+        sdk.setForcedVariations({'exp-x': 1});
+        sdk.setForcedVariations({'exp-x': 0});
+
+        final result = sdk.run(GBExperiment(
+          key: 'exp-x',
+          variations: [0, 1],
+        ));
+
+        expect(result.variationID, 0);
+      });
+
+      test('accepts empty map to clear forced variations', () async {
+        final sdk = await buildSdk();
+        sdk.setForcedVariations({'exp-clear': 1});
+        sdk.setForcedVariations({});
+        expect(sdk.context.forcedVariation, isEmpty);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // setForcedFeatures
+    // -------------------------------------------------------------------------
+    group('setForcedFeatures', () {
+      test('can be called without error', () async {
+        final sdk = await buildSdk();
+        expect(
+          () => sdk.setForcedFeatures([
+            {'feature-a': 0},
+            {'feature-b': 1},
+          ]),
+          returnsNormally,
+        );
+      });
+
+      test('accepts empty list', () async {
+        final sdk = await buildSdk();
+        expect(() => sdk.setForcedFeatures([]), returnsNormally);
+      });
+    });
+  });
+}

--- a/test/common_test/gb_sdk_remote_eval_test.dart
+++ b/test/common_test/gb_sdk_remote_eval_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
+import 'package:growthbook_sdk_flutter/src/Cache/caching_manager.dart';
+
+import '../mocks/network_mock.dart';
+
+void main() {
+  group('GrowthBookSDK — remote eval flow', () {
+    const testApiKey = '<API_KEY>';
+    const testHostURL = 'https://example.growthbook.io';
+    final cachingManager = CachingManager();
+
+    Future<GrowthBookSDK> buildSdk({
+      bool remoteEval = false,
+      bool networkError = false,
+      Map<String, dynamic>? attributes,
+      CacheRefreshHandler? refreshHandler,
+      OnInitializationFailure? onInitializationFailure,
+    }) async {
+      return GBSDKBuilderApp(
+        apiKey: testApiKey,
+        hostURL: testHostURL,
+        attributes: attributes ?? {'id': 'user-1'},
+        client: MockNetworkClient(error: networkError),
+        growthBookTrackingCallBack: (_) {},
+        backgroundSync: false,
+        remoteEval: remoteEval,
+        refreshHandler: refreshHandler,
+        onInitializationFailure: onInitializationFailure,
+      ).initialize();
+    }
+
+    tearDown(() {
+      cachingManager.clearCache();
+    });
+
+    // -------------------------------------------------------------------------
+    // refresh() — remote eval branch
+    // -------------------------------------------------------------------------
+    group('refresh with remoteEval', () {
+      test('loads features via POST when remoteEval is true', () async {
+        final sdk = await buildSdk(remoteEval: true);
+        // Mock returns features including 'onboarding'
+        expect(sdk.features, isNotEmpty);
+        expect(sdk.features.containsKey('onboarding'), isTrue);
+      });
+
+      test('explicit refresh() re-fetches features via remote eval', () async {
+        final sdk = await buildSdk(remoteEval: true);
+        // Should complete without error
+        await expectLater(sdk.refresh(), completes);
+      });
+
+      test('refreshHandler is called with true on successful remote eval', () async {
+        bool? handlerValue;
+        final sdk = await buildSdk(
+          remoteEval: true,
+          refreshHandler: (success) => handlerValue = success,
+        );
+        await sdk.refresh();
+        expect(handlerValue, isTrue);
+      });
+
+      test('refreshHandler is called with false on remote eval failure', () async {
+        bool? handlerValue;
+        await buildSdk(
+          remoteEval: true,
+          networkError: true,
+          refreshHandler: (success) => handlerValue = success,
+          onInitializationFailure: (_) {},
+        );
+        expect(handlerValue, isFalse);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // refreshForRemoteEval()
+    // -------------------------------------------------------------------------
+    group('refreshForRemoteEval', () {
+      test('does nothing when remoteEval is false', () async {
+        final sdk = await buildSdk(remoteEval: false);
+        // Should return immediately without error
+        await expectLater(sdk.refreshForRemoteEval(), completes);
+      });
+
+      test('sends current attributes and forced variations in payload', () async {
+        final sdk = await buildSdk(
+          remoteEval: true,
+          attributes: {'id': 'user-42', 'plan': 'pro'},
+        );
+        sdk.setForcedVariations({'exp-remote': 1});
+        // refreshForRemoteEval is triggered by setForcedVariations;
+        // calling explicitly should also complete without error
+        await expectLater(sdk.refreshForRemoteEval(), completes);
+      });
+
+      test('updates features after successful remote eval call', () async {
+        final sdk = await buildSdk(remoteEval: true);
+        final featuresBefore = sdk.features.length;
+        await sdk.refreshForRemoteEval();
+        expect(sdk.features.length, featuresBefore);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // isOn()
+    // -------------------------------------------------------------------------
+    group('isOn', () {
+      test('returns true for a feature with defaultValue true', () async {
+        final sdk = await buildSdk();
+        sdk.context.features = {
+          'flag-on': GBFeature(defaultValue: true),
+        };
+        expect(sdk.isOn('flag-on'), isTrue);
+      });
+
+      test('returns false for a feature with defaultValue false', () async {
+        final sdk = await buildSdk();
+        sdk.context.features = {
+          'flag-off': GBFeature(defaultValue: false),
+        };
+        expect(sdk.isOn('flag-off'), isFalse);
+      });
+
+      test('returns false for an unknown feature', () async {
+        final sdk = await buildSdk();
+        expect(sdk.isOn('nonexistent-feature'), isFalse);
+      });
+    });
+  });
+}

--- a/test/common_test/gb_sdk_saved_groups_test.dart
+++ b/test/common_test/gb_sdk_saved_groups_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
+import 'package:growthbook_sdk_flutter/src/Cache/caching_manager.dart';
+
+import '../mocks/network_mock.dart';
+
+void main() {
+  group('GrowthBookSDK — saved groups callbacks', () {
+    const testApiKey = '<API_KEY>';
+    const testHostURL = 'https://example.growthbook.io';
+    final cachingManager = CachingManager();
+
+    Future<GrowthBookSDK> buildSdk({
+      CacheRefreshHandler? refreshHandler,
+      OnInitializationFailure? onInitializationFailure,
+    }) async {
+      return GBSDKBuilderApp(
+        apiKey: testApiKey,
+        hostURL: testHostURL,
+        attributes: {'id': 'user-1'},
+        client: const MockNetworkClient(),
+        growthBookTrackingCallBack: (_) {},
+        backgroundSync: false,
+        refreshHandler: refreshHandler,
+        onInitializationFailure: onInitializationFailure,
+      ).initialize();
+    }
+
+    tearDown(() {
+      cachingManager.clearCache();
+    });
+
+    // -------------------------------------------------------------------------
+    // savedGroupsFetchedSuccessfully
+    // -------------------------------------------------------------------------
+    group('savedGroupsFetchedSuccessfully', () {
+      test('stores saved groups in context', () async {
+        final sdk = await buildSdk();
+        final groups = {'admins': ['user-1', 'user-2']};
+
+        sdk.savedGroupsFetchedSuccessfully(
+          savedGroups: groups,
+          isRemote: false,
+        );
+
+        expect(sdk.context.savedGroups, groups);
+      });
+
+      test('does not call refreshHandler when isRemote is false', () async {
+        int callCount = 0;
+        final sdk = await buildSdk(
+          refreshHandler: (_) => callCount++,
+        );
+        final countAfterInit = callCount;
+
+        sdk.savedGroupsFetchedSuccessfully(
+          savedGroups: {},
+          isRemote: false,
+        );
+
+        expect(callCount, countAfterInit);
+      });
+
+      test('calls refreshHandler with true when isRemote is true', () async {
+        bool? handlerValue;
+        final sdk = await buildSdk(
+          refreshHandler: (value) => handlerValue = value,
+        );
+
+        sdk.savedGroupsFetchedSuccessfully(
+          savedGroups: {'beta': ['user-42']},
+          isRemote: true,
+        );
+
+        expect(handlerValue, isTrue);
+      });
+
+      test('does not crash when refreshHandler is null and isRemote is true', () async {
+        final sdk = await buildSdk();
+
+        expect(
+          () => sdk.savedGroupsFetchedSuccessfully(
+            savedGroups: {},
+            isRemote: true,
+          ),
+          returnsNormally,
+        );
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // savedGroupsFetchFailed
+    // -------------------------------------------------------------------------
+    group('savedGroupsFetchFailed', () {
+      test('calls onInitializationFailure with the error', () async {
+        GBError? captured;
+        final sdk = await buildSdk(
+          onInitializationFailure: (e) => captured = e,
+        );
+
+        sdk.savedGroupsFetchFailed(error: null, isRemote: false);
+
+        // callback was invoked (even with null error)
+        expect(captured, isNull);
+      });
+
+      test('does not call refreshHandler when isRemote is false', () async {
+        int callCount = 0;
+        final sdk = await buildSdk(
+          refreshHandler: (_) => callCount++,
+        );
+        final countAfterInit = callCount;
+
+        sdk.savedGroupsFetchFailed(error: null, isRemote: false);
+
+        expect(callCount, countAfterInit);
+      });
+
+      test('calls refreshHandler with false when isRemote is true', () async {
+        bool? handlerValue;
+        final sdk = await buildSdk(
+          refreshHandler: (value) => handlerValue = value,
+        );
+
+        sdk.savedGroupsFetchFailed(error: null, isRemote: true);
+
+        expect(handlerValue, isFalse);
+      });
+
+      test('does not crash when refreshHandler is null and isRemote is true', () async {
+        final sdk = await buildSdk();
+
+        expect(
+          () => sdk.savedGroupsFetchFailed(error: null, isRemote: true),
+          returnsNormally,
+        );
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // getStickyBucketAssignmentDocs
+    // -------------------------------------------------------------------------
+    group('getStickyBucketAssignmentDocs', () {
+      test('returns empty map when no sticky bucket service is configured', () async {
+        final sdk = await buildSdk();
+        expect(sdk.getStickyBucketAssignmentDocs(), isEmpty);
+      });
+
+      test('returns empty map when stickyBucketAssignmentDocs is null', () async {
+        final sdk = await buildSdk();
+        sdk.context.stickyBucketAssignmentDocs = null;
+        expect(sdk.getStickyBucketAssignmentDocs(), isEmpty);
+      });
+    });
+  });
+}

--- a/test/common_test/gb_sdk_subscriptions_test.dart
+++ b/test/common_test/gb_sdk_subscriptions_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
+import 'package:growthbook_sdk_flutter/src/Cache/caching_manager.dart';
+
+import '../mocks/network_mock.dart';
+
+void main() {
+  group('GrowthBookSDK — subscriptions', () {
+    const testApiKey = '<API_KEY>';
+    const testHostURL = 'https://example.growthbook.io';
+    const client = MockNetworkClient();
+    final cachingManager = CachingManager();
+
+    Future<GrowthBookSDK> buildSdk({Map<String, dynamic>? attributes}) async {
+      return GBSDKBuilderApp(
+        apiKey: testApiKey,
+        hostURL: testHostURL,
+        attributes: attributes ?? {'id': 'user-1'},
+        client: client,
+        growthBookTrackingCallBack: (_) {},
+        backgroundSync: false,
+      ).initialize();
+    }
+
+    tearDown(() {
+      cachingManager.clearCache();
+    });
+
+    // -------------------------------------------------------------------------
+    // getAllResults
+    // -------------------------------------------------------------------------
+    group('getAllResults', () {
+      test('returns empty map before any experiment runs', () async {
+        final sdk = await buildSdk();
+        expect(sdk.getAllResults(), isEmpty);
+      });
+
+      test('contains result after running an experiment', () async {
+        final sdk = await buildSdk();
+        sdk.run(GBExperiment(key: 'exp-a', variations: [0, 1]));
+        expect(sdk.getAllResults(), contains('exp-a'));
+      });
+
+      test('accumulates results for multiple experiments', () async {
+        final sdk = await buildSdk();
+        sdk.run(GBExperiment(key: 'exp-a', variations: [0, 1]));
+        sdk.run(GBExperiment(key: 'exp-b', variations: [0, 1]));
+        final results = sdk.getAllResults();
+        expect(results.length, 2);
+        expect(results.containsKey('exp-a'), isTrue);
+        expect(results.containsKey('exp-b'), isTrue);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // subscribe / unsubscribe
+    // -------------------------------------------------------------------------
+    group('subscribe', () {
+      test('callback is invoked when a new experiment is run', () async {
+        final sdk = await buildSdk();
+        GBExperiment? receivedExperiment;
+        GBExperimentResult? receivedResult;
+
+        sdk.subscribe((experiment, result) {
+          receivedExperiment = experiment;
+          receivedResult = result;
+        });
+
+        sdk.run(GBExperiment(key: 'exp-sub', variations: [0, 1]));
+
+        expect(receivedExperiment, isNotNull);
+        expect(receivedExperiment!.key, 'exp-sub');
+        expect(receivedResult, isNotNull);
+      });
+
+      test('unsubscribe function stops future callbacks', () async {
+        final sdk = await buildSdk();
+        int callCount = 0;
+
+        final unsubscribe = sdk.subscribe((_, __) => callCount++);
+
+        sdk.run(GBExperiment(key: 'exp-1', variations: [0, 1]));
+        expect(callCount, 1);
+
+        unsubscribe();
+
+        sdk.run(GBExperiment(key: 'exp-2', variations: [0, 1]));
+        expect(callCount, 1);
+      });
+
+      test('multiple subscribers each receive the callback', () async {
+        final sdk = await buildSdk();
+        int count1 = 0;
+        int count2 = 0;
+
+        sdk.subscribe((_, __) => count1++);
+        sdk.subscribe((_, __) => count2++);
+
+        sdk.run(GBExperiment(key: 'exp-multi', variations: [0, 1]));
+
+        expect(count1, 1);
+        expect(count2, 1);
+      });
+
+      test('callback receives correct experiment key and result', () async {
+        final sdk = await buildSdk();
+        final captured = <Map<String, dynamic>>[];
+
+        sdk.subscribe((experiment, result) {
+          captured.add({'key': experiment.key, 'variationID': result.variationID});
+        });
+
+        sdk.run(GBExperiment(key: 'exp-check', variations: [0, 1]));
+
+        expect(captured.length, 1);
+        expect(captured.first['key'], 'exp-check');
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // fireSubscriptions — deduplication logic
+    // -------------------------------------------------------------------------
+    group('fireSubscriptions', () {
+      test('does not re-fire when same experiment produces identical result', () async {
+        final sdk = await buildSdk();
+        int callCount = 0;
+        sdk.subscribe((_, __) => callCount++);
+
+        final experiment = GBExperiment(key: 'exp-dedup', variations: [0, 1]);
+        sdk.run(experiment); // first run — fires (no previous assignment)
+        sdk.run(experiment); // same result — must not fire again
+        expect(callCount, 1);
+      });
+
+      test('fires again when forced variationID changes between runs', () async {
+        final sdk = await buildSdk();
+        int callCount = 0;
+        sdk.subscribe((_, __) => callCount++);
+
+        sdk.run(GBExperiment(key: 'exp-change', variations: [0, 1], force: 0));
+        expect(callCount, 1);
+
+        // force different variation → variationID changes → subscription fires
+        sdk.run(GBExperiment(key: 'exp-change', variations: [0, 1], force: 1));
+        expect(callCount, 2);
+      });
+
+      test('independent experiments each fire their own subscription event', () async {
+        final sdk = await buildSdk();
+        int callCount = 0;
+        sdk.subscribe((_, __) => callCount++);
+
+        sdk.run(GBExperiment(key: 'exp-x', variations: [0, 1]));
+        sdk.run(GBExperiment(key: 'exp-y', variations: [0, 1]));
+        expect(callCount, 2);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // clearSubscriptions
+    // -------------------------------------------------------------------------
+    group('clearSubscriptions', () {
+      test('removes all active subscriptions', () async {
+        final sdk = await buildSdk();
+        int callCount = 0;
+
+        sdk.subscribe((_, __) => callCount++);
+        sdk.subscribe((_, __) => callCount++);
+        sdk.clearSubscriptions();
+
+        sdk.run(GBExperiment(key: 'exp-clear', variations: [0, 1]));
+        expect(callCount, 0);
+      });
+
+      test('subscriptions added after clear still work', () async {
+        final sdk = await buildSdk();
+        int callCount = 0;
+
+        sdk.subscribe((_, __) => callCount++);
+        sdk.clearSubscriptions();
+        sdk.subscribe((_, __) => callCount++);
+
+        sdk.run(GBExperiment(key: 'exp-after-clear', variations: [0, 1]));
+        expect(callCount, 1);
+      });
+    });
+  });
+}

--- a/test/common_test/lru_cache_and_feature_evaluator_test.dart
+++ b/test/common_test/lru_cache_and_feature_evaluator_test.dart
@@ -1,0 +1,310 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
+import 'package:growthbook_sdk_flutter/src/Cache/caching_manager.dart';
+import 'package:growthbook_sdk_flutter/src/Evaluator/feature_evaluator.dart';
+import 'package:growthbook_sdk_flutter/src/Model/gb_parent_condition.dart';
+import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/evaluation_context.dart';
+import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/global_context.dart';
+import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/options.dart';
+import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/user_context.dart';
+import 'package:growthbook_sdk_flutter/src/Network/lru_etag_cache.dart';
+import 'package:growthbook_sdk_flutter/src/StickyBucketService/sticky_bucket_service.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+class _InMemoryCache implements CachingLayer {
+  final _store = <String, Uint8List>{};
+
+  @override
+  Future<Uint8List?> getContent({required String fileName}) async =>
+      _store[fileName];
+
+  @override
+  Future<void> saveContent(
+          {required String fileName, required Uint8List content}) async =>
+      _store[fileName] = content;
+}
+
+EvaluationContext _ctx({
+  Map<String, dynamic>? features,
+  void Function(String, GBFeatureResult)? featureUsageCallback,
+  StickyBucketService? stickyBucketService,
+  Map<String, dynamic>? forcedVariations,
+  Map<String, dynamic>? attributes,
+}) =>
+    EvaluationContext(
+      globalContext: GlobalContext(features: features ?? {}),
+      userContext: UserContext(
+        attributes: attributes ?? {'id': 'user-1'},
+        forcedVariationsMap: forcedVariations ?? {},
+      ),
+      stackContext: StackContext(),
+      options: Options(
+        enabled: true,
+        isQaMode: false,
+        isCacheDisabled: false,
+        trackingCallBackWithUser: (_) {},
+        featureUsageCallbackWithUser: featureUsageCallback,
+        stickyBucketService: stickyBucketService,
+      ),
+    );
+
+// ---------------------------------------------------------------------------
+// LruEtagCache
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('LruEtagCache', () {
+    test('put with null etag removes existing entry', () {
+      final cache = LruEtagCache();
+      cache.put('http://a.com', '"v1"');
+      expect(cache.get('http://a.com'), '"v1"');
+
+      cache.put('http://a.com', null);
+      expect(cache.get('http://a.com'), isNull);
+    });
+
+    test('contains returns true for stored URL and false for missing', () {
+      final cache = LruEtagCache();
+      cache.put('http://a.com', '"v1"');
+      expect(cache.contains('http://a.com'), isTrue);
+      expect(cache.contains('http://b.com'), isFalse);
+    });
+
+    test('remove returns the removed value', () {
+      final cache = LruEtagCache();
+      cache.put('http://a.com', '"v1"');
+      final removed = cache.remove('http://a.com');
+      expect(removed, '"v1"');
+      expect(cache.contains('http://a.com'), isFalse);
+    });
+
+    test('clear empties the cache', () {
+      final cache = LruEtagCache();
+      cache.put('http://a.com', '"v1"');
+      cache.put('http://b.com', '"v2"');
+      cache.clear();
+      expect(cache.size(), 0);
+    });
+
+    test('size returns the number of entries', () {
+      final cache = LruEtagCache();
+      expect(cache.size(), 0);
+      cache.put('http://a.com', '"v1"');
+      cache.put('http://b.com', '"v2"');
+      expect(cache.size(), 2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // FeatureEvaluator
+  // -------------------------------------------------------------------------
+
+  group('FeatureEvaluator', () {
+    // -----------------------------------------------------------------------
+    // Cyclic prerequisite — lines 25 and 67
+    // -----------------------------------------------------------------------
+    group('cyclic prerequisite', () {
+      test('returns cyclicPrerequisite source and triggers featureUsageCallback',
+          () {
+        // feat-a has parentCondition → feat-b
+        // feat-b has parentCondition → feat-a  (creates a cycle)
+        final featA = GBFeature(rules: [
+          GBFeatureRule(
+            parentConditions: [
+              GBParentCondition(id: 'feat-b', condition: {'value': true}),
+            ],
+            force: 'a',
+          ),
+        ]);
+        final featB = GBFeature(rules: [
+          GBFeatureRule(
+            parentConditions: [
+              GBParentCondition(id: 'feat-a', condition: {'value': true}),
+            ],
+            force: 'b',
+          ),
+        ]);
+
+        final calls = <String>[];
+        final ctx = _ctx(
+          features: {'feat-a': featA, 'feat-b': featB},
+          featureUsageCallback: (key, _) => calls.add(key),
+        );
+
+        final result = FeatureEvaluator().evaluateFeature(ctx, 'feat-a');
+        expect(result.source, GBFeatureSource.cyclicPrerequisite);
+        expect(calls, isNotEmpty);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Blocked by prerequisite — line 92
+    // -----------------------------------------------------------------------
+    group('blocked by prerequisite', () {
+      test('returns prerequisite source when gate condition fails', () {
+        // feat-b returns false (defaultValue)
+        // feat-a requires feat-b.value == true (gate: true)
+        final featB = GBFeature(defaultValue: false);
+        final featA = GBFeature(rules: [
+          GBFeatureRule(
+            parentConditions: [
+              GBParentCondition(
+                id: 'feat-b',
+                condition: {'value': true},
+                gate: true,
+              ),
+            ],
+            force: 'a',
+          ),
+        ]);
+
+        GBFeatureSource? capturedSource;
+        final ctx = _ctx(
+          features: {'feat-a': featA, 'feat-b': featB},
+          featureUsageCallback: (key, result) {
+            if (key == 'feat-a') capturedSource = result.source;
+          },
+        );
+
+        final result = FeatureEvaluator().evaluateFeature(ctx, 'feat-a');
+        expect(result.source, GBFeatureSource.prerequisite);
+        expect(capturedSource, GBFeatureSource.prerequisite);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Forced value with stickyBucketService — lines 127 and 155
+    // -----------------------------------------------------------------------
+    group('forced feature with stickyBucketService', () {
+      test('returns forced value and triggers callback, uses fallbackAttribute',
+          () {
+        final featA = GBFeature(rules: [
+          GBFeatureRule(
+            force: 'forced',
+            coverage: 1.0,
+            fallbackAttribute: 'device',
+            disableStickyBucketing: false,
+          ),
+        ]);
+
+        bool callbackCalled = false;
+        final svc =
+            LocalStorageStickyBucketService(localStorage: _InMemoryCache());
+        final ctx = _ctx(
+          features: {'feat-a': featA},
+          featureUsageCallback: (_, __) => callbackCalled = true,
+          stickyBucketService: svc,
+        );
+
+        final result = FeatureEvaluator().evaluateFeature(ctx, 'feat-a');
+        expect(result.source, GBFeatureSource.force);
+        expect(result.value, 'forced');
+        expect(callbackCalled, isTrue);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Experiment result callback — line 195
+    // -----------------------------------------------------------------------
+    group('experiment result', () {
+      test('triggers featureUsageCallback when user is in experiment', () {
+        final featA = GBFeature(rules: [
+          GBFeatureRule(
+            key: 'exp-key',
+            variations: ['control', 'treatment'],
+            weights: [0.5, 0.5],
+            coverage: 1.0,
+          ),
+        ]);
+
+        bool callbackCalled = false;
+        final ctx = _ctx(
+          features: {'feat-a': featA},
+          featureUsageCallback: (_, __) => callbackCalled = true,
+          forcedVariations: {'exp-key': 1},
+        );
+
+        final result = FeatureEvaluator().evaluateFeature(ctx, 'feat-a');
+        expect(result.source, GBFeatureSource.experiment);
+        expect(callbackCalled, isTrue);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Default value callback — line 203
+    // -----------------------------------------------------------------------
+    group('default value', () {
+      test('triggers featureUsageCallback on default value path', () {
+        final featA = GBFeature(defaultValue: 'default');
+        bool callbackCalled = false;
+        final ctx = _ctx(
+          features: {'feat-a': featA},
+          featureUsageCallback: (_, __) => callbackCalled = true,
+        );
+
+        final result = FeatureEvaluator().evaluateFeature(ctx, 'feat-a');
+        expect(result.value, 'default');
+        expect(result.source, GBFeatureSource.defaultValue);
+        expect(callbackCalled, isTrue);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // getAttributes — lines 232-245
+    // -----------------------------------------------------------------------
+    group('getAttributes', () {
+      test('returns merged attributes map', () {
+        final context = GBContext(
+          apiKey: 'key',
+          hostURL: 'https://example.com',
+          attributes: {'id': 'user-1', 'plan': 'pro'},
+          enabled: true,
+          forcedVariation: {},
+          qaMode: false,
+          trackingCallBack: (_) {},
+        );
+        final result = FeatureEvaluator().getAttributes(context);
+        expect(result['id'], 'user-1');
+        expect(result['plan'], 'pro');
+      });
+
+      test('returns empty map when attributes is null', () {
+        final context = GBContext(
+          apiKey: 'key',
+          hostURL: 'https://example.com',
+          enabled: true,
+          forcedVariation: {},
+          qaMode: false,
+          trackingCallBack: (_) {},
+        );
+        final result = FeatureEvaluator().getAttributes(context);
+        expect(result, isEmpty);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // FeatureEvalContext constructor — lines 254-257
+    // -----------------------------------------------------------------------
+    group('FeatureEvalContext', () {
+      test('initialises with defaults', () {
+        final ctx = FeatureEvalContext();
+        expect(ctx.id, isNull);
+        expect(ctx.evaluatedFeatures, isEmpty);
+      });
+
+      test('initialises with provided values', () {
+        final ctx = FeatureEvalContext(
+          id: 'feat-a',
+          evaluatedFeatures: {'feat-b'},
+        );
+        expect(ctx.id, 'feat-a');
+        expect(ctx.evaluatedFeatures, contains('feat-b'));
+      });
+    });
+  });
+}

--- a/test/common_test/lru_cache_and_feature_evaluator_test.dart
+++ b/test/common_test/lru_cache_and_feature_evaluator_test.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
 import 'package:growthbook_sdk_flutter/src/Cache/caching_manager.dart';
-import 'package:growthbook_sdk_flutter/src/Evaluator/feature_evaluator.dart';
 import 'package:growthbook_sdk_flutter/src/Model/gb_parent_condition.dart';
 import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/evaluation_context.dart';
 import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/global_context.dart';

--- a/test/common_test/model_data_classes_test.dart
+++ b/test/common_test/model_data_classes_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
+import 'package:growthbook_sdk_flutter/src/Model/gb_parent_condition.dart';
+import 'package:growthbook_sdk_flutter/src/Model/remote_eval_model.dart';
+import 'package:growthbook_sdk_flutter/src/Utils/gb_variation_meta.dart';
+
+void main() {
+  // -------------------------------------------------------------------------
+  // GBExperimentResult
+  // -------------------------------------------------------------------------
+  group('GBExperimentResult', () {
+    group('fromJson / toJson', () {
+      test('round-trips basic fields', () {
+        final result = GBExperimentResult(
+          inExperiment: true,
+          key: '1',
+          variationID: 1,
+          value: 'blue',
+          bucket: 0.42,
+          featureId: 'feat-a',
+          hashAttribute: 'id',
+          hashUsed: true,
+          hashValue: 'user-1',
+          stickyBucketUsed: false,
+          name: 'Variation B',
+          passthrough: false,
+        );
+
+        final json = result.toJson();
+        final restored = GBExperimentResult.fromJson(json);
+
+        expect(restored.inExperiment, isTrue);
+        expect(restored.key, '1');
+        expect(restored.variationID, 1);
+        expect(restored.value, 'blue');
+        expect(restored.bucket, 0.42);
+        expect(restored.featureId, 'feat-a');
+        expect(restored.hashAttribute, 'id');
+        expect(restored.hashUsed, isTrue);
+        expect(restored.hashValue, 'user-1');
+        expect(restored.stickyBucketUsed, isFalse);
+        expect(restored.name, 'Variation B');
+        expect(restored.passthrough, isFalse);
+      });
+
+      test('_toStringValue converts non-string hashValue to string', () {
+        final json = {
+          'inExperiment': true,
+          'key': 0,
+          'hashValue': 12345,
+        };
+        final result = GBExperimentResult.fromJson(json);
+        expect(result.hashValue, '12345');
+      });
+
+      test('_toStringValue returns null for null hashValue', () {
+        final json = {
+          'inExperiment': false,
+          'key': '0',
+          'hashValue': null,
+        };
+        final result = GBExperimentResult.fromJson(json);
+        expect(result.hashValue, isNull);
+      });
+
+      test('_toStringRequired converts int key to string', () {
+        final json = {'inExperiment': false, 'key': 42};
+        final result = GBExperimentResult.fromJson(json);
+        expect(result.key, '42');
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GBVariationMeta
+  // -------------------------------------------------------------------------
+  group('GBVariationMeta', () {
+    group('toJson / fromJson', () {
+      test('round-trips all fields', () {
+        final meta = GBVariationMeta(key: 'v1', name: 'Control', passthrough: true);
+        final json = meta.toJson();
+        final restored = GBVariationMeta.fromJson(json);
+
+        expect(restored.key, 'v1');
+        expect(restored.name, 'Control');
+        expect(restored.passthrough, isTrue);
+      });
+    });
+
+    group('toString', () {
+      test('contains all field values', () {
+        final meta = GBVariationMeta(key: 'v2', name: 'Treatment', passthrough: false);
+        final str = meta.toString();
+        expect(str, contains('v2'));
+        expect(str, contains('Treatment'));
+        expect(str, contains('false'));
+      });
+
+      test('does not throw with null fields', () {
+        final meta = GBVariationMeta();
+        expect(() => meta.toString(), returnsNormally);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GBTrack
+  // -------------------------------------------------------------------------
+  group('GBTrack', () {
+    group('toJson / fromJson', () {
+      test('round-trips with null fields', () {
+        final track = GBTrack();
+        final json = track.toJson();
+        final restored = GBTrack.fromJson(json);
+        expect(restored.experiment, isNull);
+        expect(restored.result, isNull);
+      });
+    });
+
+    group('toString', () {
+      test('does not throw with null fields', () {
+        final track = GBTrack();
+        expect(() => track.toString(), returnsNormally);
+      });
+
+      test('contains experiment and result labels', () {
+        final track = GBTrack();
+        final str = track.toString();
+        expect(str, contains('experiment'));
+        expect(str, contains('result'));
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // RemoteEvalModel
+  // -------------------------------------------------------------------------
+  group('RemoteEvalModel', () {
+    group('fromJson / toJson', () {
+      test('round-trips all fields', () {
+        final model = RemoteEvalModel(
+          attributes: {'id': 'user-1'},
+          forcedFeatures: ['feat-a'],
+          forcedVariations: {'exp-1': 0},
+        );
+        final json = model.toJson();
+        final restored = RemoteEvalModel.fromJson(json);
+
+        expect(restored.attributes, {'id': 'user-1'});
+        expect(restored.forcedFeatures, ['feat-a']);
+        expect(restored.forcedVariations, {'exp-1': 0});
+      });
+
+      test('fromJson handles null fields', () {
+        final restored = RemoteEvalModel.fromJson({});
+        expect(restored.attributes, isNull);
+        expect(restored.forcedFeatures, isNull);
+        expect(restored.forcedVariations, isNull);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GBParentCondition
+  // -------------------------------------------------------------------------
+  group('GBParentCondition', () {
+    group('toJson / fromJson', () {
+      test('round-trips all fields', () {
+        final cond = GBParentCondition(
+          id: 'parent-feat',
+          condition: {'value': true},
+          gate: true,
+        );
+        final json = cond.toJson();
+        final restored = GBParentCondition.fromJson(json);
+
+        expect(restored.id, 'parent-feat');
+        expect(restored.condition, {'value': true});
+        expect(restored.gate, isTrue);
+      });
+
+      test('round-trips with null gate', () {
+        final cond = GBParentCondition(id: 'feat', condition: {});
+        final json = cond.toJson();
+        final restored = GBParentCondition.fromJson(json);
+        expect(restored.gate, isNull);
+      });
+    });
+  });
+}

--- a/test/common_test/sse_layer_test.dart
+++ b/test/common_test/sse_layer_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/src/Network/see_event_collector.dart';
+import 'package:growthbook_sdk_flutter/src/Network/sse_event.dart';
+import 'package:growthbook_sdk_flutter/src/Network/sse_event_parser.dart';
+import 'package:growthbook_sdk_flutter/src/Network/sse_event_transformer.dart';
+
+void main() {
+  // -------------------------------------------------------------------------
+  // SseEvent — data class
+  // -------------------------------------------------------------------------
+  group('SseEvent', () {
+    test('toString includes id, name, and data', () {
+      const event = SseEvent(id: '1', name: 'features', data: '{}');
+      final str = event.toString();
+      expect(str, contains('1'));
+      expect(str, contains('features'));
+      expect(str, contains('{}'));
+    });
+
+    test('two events with same fields are equal', () {
+      const a = SseEvent(id: '1', name: 'ping', data: 'x');
+      const b = SseEvent(id: '1', name: 'ping', data: 'x');
+      expect(a, equals(b));
+    });
+
+    test('events differ when any field differs', () {
+      const base = SseEvent(id: '1', name: 'ping', data: 'x');
+      expect(base == const SseEvent(id: '2', name: 'ping', data: 'x'), isFalse);
+      expect(base == const SseEvent(id: '1', name: 'push', data: 'x'), isFalse);
+      expect(base == const SseEvent(id: '1', name: 'ping', data: 'y'), isFalse);
+    });
+
+    test('identical reference is equal to itself', () {
+      const event = SseEvent(id: '1', name: 'ping', data: 'x');
+      // ignore: unrelated_type_equality_checks
+      expect(event == event, isTrue);
+    });
+
+    test('equal events have the same hashCode', () {
+      const a = SseEvent(id: '42', name: 'ev', data: 'payload');
+      const b = SseEvent(id: '42', name: 'ev', data: 'payload');
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('works with all-null fields', () {
+      const event = SseEvent();
+      expect(event.id, isNull);
+      expect(event.name, isNull);
+      expect(event.data, isNull);
+      expect(() => event.toString(), returnsNormally);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SseEventCollector — groups lines by double-newline separator
+  // -------------------------------------------------------------------------
+  group('SseEventCollector', () {
+    test('yields one group of lines for a single SSE event', () async {
+      final input = Stream.fromIterable(['id: 1\nevent: ping\ndata: {}\n\n']);
+      final result = await input.transform(SseEventCollector()).toList();
+      expect(result, [
+        ['id: 1', 'event: ping', 'data: {}']
+      ]);
+    });
+
+    test('yields multiple groups for multiple SSE events', () async {
+      final input = Stream.fromIterable([
+        'event: a\ndata: 1\n\nevent: b\ndata: 2\n\n',
+      ]);
+      final result = await input.transform(SseEventCollector()).toList();
+      expect(result.length, 2);
+      expect(result[0], ['event: a', 'data: 1']);
+      expect(result[1], ['event: b', 'data: 2']);
+    });
+
+    test('handles chunks arriving as separate stream items', () async {
+      final input = Stream.fromIterable([
+        'event: test\n',
+        'data: hello\n',
+        '\n',
+      ]);
+      final result = await input.transform(SseEventCollector()).toList();
+      expect(result, [
+        ['event: test', 'data: hello']
+      ]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SseEventParser — maps List<String> lines to SseEvent
+  // -------------------------------------------------------------------------
+  group('SseEventParser', () {
+    test('parses standard id / event / data fields', () async {
+      final input = Stream.fromIterable([
+        ['id: 42', 'event: features', 'data: {"key":"val"}'],
+      ]);
+      final result = await input.transform(const SseEventParser()).toList();
+      expect(result.single, const SseEvent(id: '42', name: 'features', data: '{"key":"val"}'));
+    });
+
+    test('line without colon is stored with empty value', () async {
+      final input = Stream.fromIterable([
+        ['ping'],
+      ]);
+      final result = await input.transform(const SseEventParser()).toList();
+      // No id/event/data fields → all null
+      expect(result.single, const SseEvent());
+    });
+
+    test('field names are lowercased', () async {
+      final input = Stream.fromIterable([
+        ['ID: 1', 'EVENT: push', 'DATA: {}'],
+      ]);
+      final result = await input.transform(const SseEventParser()).toList();
+      expect(result.single, const SseEvent(id: '1', name: 'push', data: '{}'));
+    });
+
+    test('leading and trailing whitespace is trimmed from values', () async {
+      final input = Stream.fromIterable([
+        ['data:   trimmed   '],
+      ]);
+      final result = await input.transform(const SseEventParser()).toList();
+      expect(result.single.data, 'trimmed');
+    });
+
+    test('yields one SseEvent per input list', () async {
+      final input = Stream.fromIterable([
+        ['data: first'],
+        ['data: second'],
+      ]);
+      final result = await input.transform(const SseEventParser()).toList();
+      expect(result.length, 2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SseEventTransformer — end-to-end raw SSE string → SseEvent
+  // -------------------------------------------------------------------------
+  group('SseEventTransformer', () {
+    test('parses a complete SSE event from raw stream', () async {
+      final input = Stream.fromIterable([
+        'id: 1\nevent: features\ndata: {"status":200}\n\n',
+      ]);
+      final result = await input.transform(const SseEventTransformer()).toList();
+      expect(result.single, const SseEvent(
+        id: '1',
+        name: 'features',
+        data: '{"status":200}',
+      ));
+    });
+
+    test('parses multiple events from a single stream', () async {
+      final input = Stream.fromIterable([
+        'event: ping\ndata: 1\n\nevent: ping\ndata: 2\n\n',
+      ]);
+      final result = await input.transform(const SseEventTransformer()).toList();
+      expect(result.length, 2);
+      expect(result[0].name, 'ping');
+      expect(result[1].data, '2');
+    });
+
+    test('handles empty data field', () async {
+      final input = Stream.fromIterable(['event: heartbeat\ndata:\n\n']);
+      final result = await input.transform(const SseEventTransformer()).toList();
+      expect(result.single.name, 'heartbeat');
+      expect(result.single.data, '');
+    });
+  });
+}

--- a/test/common_test/sticky_bucket_service_test.dart
+++ b/test/common_test/sticky_bucket_service_test.dart
@@ -1,0 +1,186 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/src/Cache/caching_manager.dart';
+import 'package:growthbook_sdk_flutter/src/Model/sticky_assignments_document.dart';
+import 'package:growthbook_sdk_flutter/src/StickyBucketService/sticky_bucket_service.dart';
+
+// In-memory CachingLayer to avoid touching the real filesystem between tests.
+class _InMemoryCache implements CachingLayer {
+  final _store = <String, Uint8List>{};
+
+  @override
+  Future<Uint8List?> getContent({required String fileName}) async =>
+      _store[fileName];
+
+  @override
+  Future<void> saveContent({
+    required String fileName,
+    required Uint8List content,
+  }) async =>
+      _store[fileName] = content;
+}
+
+// CachingLayer that always throws on both read and write.
+class _ThrowingCache implements CachingLayer {
+  @override
+  Future<Uint8List?> getContent({required String fileName}) =>
+      throw Exception('storage unavailable');
+
+  @override
+  Future<void> saveContent({
+    required String fileName,
+    required Uint8List content,
+  }) =>
+      throw Exception('storage unavailable');
+}
+
+LocalStorageStickyBucketService _makeService({CachingLayer? cache}) =>
+    LocalStorageStickyBucketService(
+      localStorage: cache ?? _InMemoryCache(),
+    );
+
+StickyAssignmentsDocument _doc({
+  String name = 'id',
+  String value = 'user-1',
+  Map<String, String>? assignments,
+}) =>
+    StickyAssignmentsDocument(
+      attributeName: name,
+      attributeValue: value,
+      assignments: assignments ?? {'exp__0': '0'},
+    );
+
+void main() {
+  group('LocalStorageStickyBucketService', () {
+    // -------------------------------------------------------------------------
+    // getAssignments
+    // -------------------------------------------------------------------------
+    group('getAssignments', () {
+      test('returns null when nothing is stored', () async {
+        final svc = _makeService();
+        final result = await svc.getAssignments('id', 'user-1');
+        expect(result, isNull);
+      });
+
+      test('returns the stored document after saveAssignments', () async {
+        final svc = _makeService();
+        final doc = _doc();
+        await svc.saveAssignments(doc);
+        final result = await svc.getAssignments('id', 'user-1');
+        expect(result, isNotNull);
+        expect(result!.attributeName, 'id');
+        expect(result.attributeValue, 'user-1');
+        expect(result.assignments['exp__0'], '0');
+      });
+
+      test('returns null and does not throw when cache throws', () async {
+        final svc = _makeService(cache: _ThrowingCache());
+        final result = await svc.getAssignments('id', 'user-1');
+        expect(result, isNull);
+      });
+
+      test('returns null when stored bytes are corrupt JSON', () async {
+        final cache = _InMemoryCache();
+        const prefix = 'gbStickyBuckets__';
+        cache._store['${prefix}id||user-1'] =
+            Uint8List.fromList(utf8.encode('not-valid-json'));
+
+        final svc = LocalStorageStickyBucketService(localStorage: cache);
+        final result = await svc.getAssignments('id', 'user-1');
+        expect(result, isNull);
+      });
+
+      test('returns null when localStorage is null', () async {
+        final svc = _makeService();
+        svc.localStorage = null;
+        final result = await svc.getAssignments('id', 'user-1');
+        expect(result, isNull);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // saveAssignments
+    // -------------------------------------------------------------------------
+    group('saveAssignments', () {
+      test('does not throw when localStorage is null', () async {
+        final svc = _makeService();
+        svc.localStorage = null;
+        await expectLater(svc.saveAssignments(_doc()), completes);
+      });
+
+      test('does not throw when cache throws', () async {
+        final svc = _makeService(cache: _ThrowingCache());
+        await expectLater(svc.saveAssignments(_doc()), completes);
+      });
+
+      test('stores data under prefix + attributeName||attributeValue key', () async {
+        final cache = _InMemoryCache();
+        const prefix = 'gbStickyBuckets__';
+        final svc = LocalStorageStickyBucketService(localStorage: cache);
+
+        await svc.saveAssignments(_doc(name: 'device', value: 'abc'));
+
+        expect(cache._store.containsKey('${prefix}device||abc'), isTrue);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // getAllAssignments
+    // -------------------------------------------------------------------------
+    group('getAllAssignments', () {
+      test('returns empty map for empty attributes', () async {
+        final svc = _makeService();
+        final result = await svc.getAllAssignments({});
+        expect(result, isEmpty);
+      });
+
+      test('returns empty map when no assignments are saved', () async {
+        final svc = _makeService();
+        final result = await svc.getAllAssignments({'id': 'user-1'});
+        expect(result, isEmpty);
+      });
+
+      test('returns one entry when one attribute has a saved document', () async {
+        final svc = _makeService();
+        await svc.saveAssignments(_doc(name: 'id', value: 'user-1'));
+
+        final result = await svc.getAllAssignments({'id': 'user-1'});
+
+        expect(result.length, 1);
+        expect(result.containsKey('id||user-1'), isTrue);
+        expect(result['id||user-1']!.attributeValue, 'user-1');
+      });
+
+      test('returns multiple entries when multiple attributes have saved docs', () async {
+        final svc = _makeService();
+        await svc.saveAssignments(_doc(name: 'id', value: 'user-1'));
+        await svc.saveAssignments(_doc(name: 'device', value: 'device-42'));
+
+        final result = await svc.getAllAssignments({
+          'id': 'user-1',
+          'device': 'device-42',
+        });
+
+        expect(result.length, 2);
+        expect(result.containsKey('id||user-1'), isTrue);
+        expect(result.containsKey('device||device-42'), isTrue);
+      });
+
+      test('skips attributes that have no saved document', () async {
+        final svc = _makeService();
+        await svc.saveAssignments(_doc(name: 'id', value: 'user-1'));
+
+        final result = await svc.getAllAssignments({
+          'id': 'user-1',
+          'device': 'unknown',
+        });
+
+        expect(result.length, 1);
+        expect(result.containsKey('id||user-1'), isTrue);
+        expect(result.containsKey('device||unknown'), isFalse);
+      });
+    });
+  });
+}

--- a/test/common_test/utility_classes_test.dart
+++ b/test/common_test/utility_classes_test.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
 import 'package:growthbook_sdk_flutter/src/Cache/caching_manager.dart';
-import 'package:growthbook_sdk_flutter/src/Model/sticky_assignments_document.dart';
 import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/evaluation_context.dart';
 import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/global_context.dart';
 import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/options.dart';
@@ -11,7 +10,6 @@ import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/user_context.dart
 import 'package:growthbook_sdk_flutter/src/StickyBucketService/sticky_bucket_service.dart';
 import 'package:growthbook_sdk_flutter/src/Utils/feature_url_builder.dart';
 import 'package:growthbook_sdk_flutter/src/Utils/gb_filter.dart';
-import 'package:growthbook_sdk_flutter/src/Utils/gb_utils.dart';
 import 'package:growthbook_sdk_flutter/src/Utils/gb_variation_meta.dart';
 
 // ---------------------------------------------------------------------------
@@ -287,17 +285,17 @@ void main() {
   group('RoundToExtension', () {
     test('roundTo rounds to given fraction digits', () {
       // Use int literal (extends num) so RoundToExtension takes priority over DoubleExt
-      final n = 3 as num;
+      const n = 3 as num;
       expect(n.roundTo(numFractionDigits: 4), 3.0);
     });
 
     test('roundTo with 0 fraction digits (default) returns whole number', () {
-      final n = 5 as num;
+      const n = 5 as num;
       expect(n.roundTo(numFractionDigits: 0), 5.0);
     });
 
     test('roundTo clamps negative fractionDigits to 0', () {
-      final n = 7 as num;
+      const n = 7 as num;
       expect(() => n.roundTo(numFractionDigits: -1), returnsNormally);
     });
   });

--- a/test/common_test/utility_classes_test.dart
+++ b/test/common_test/utility_classes_test.dart
@@ -1,0 +1,304 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
+import 'package:growthbook_sdk_flutter/src/Cache/caching_manager.dart';
+import 'package:growthbook_sdk_flutter/src/Model/sticky_assignments_document.dart';
+import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/evaluation_context.dart';
+import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/global_context.dart';
+import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/options.dart';
+import 'package:growthbook_sdk_flutter/src/MultiUserMode/Model/user_context.dart';
+import 'package:growthbook_sdk_flutter/src/StickyBucketService/sticky_bucket_service.dart';
+import 'package:growthbook_sdk_flutter/src/Utils/feature_url_builder.dart';
+import 'package:growthbook_sdk_flutter/src/Utils/gb_filter.dart';
+import 'package:growthbook_sdk_flutter/src/Utils/gb_utils.dart';
+import 'package:growthbook_sdk_flutter/src/Utils/gb_variation_meta.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+class _InMemoryCache implements CachingLayer {
+  final _store = <String, Uint8List>{};
+
+  @override
+  Future<Uint8List?> getContent({required String fileName}) async =>
+      _store[fileName];
+
+  @override
+  Future<void> saveContent(
+          {required String fileName, required Uint8List content}) async =>
+      _store[fileName] = content;
+}
+
+EvaluationContext _evalContext({
+  Map<String, dynamic>? attributes,
+  Map<StickyAttributeKey, StickyAssignmentsDocument>? docs,
+}) =>
+    EvaluationContext(
+      globalContext: GlobalContext(),
+      userContext: UserContext(
+        attributes: attributes ?? {'id': 'user-1'},
+        stickyBucketAssignmentDocs: docs,
+      ),
+      stackContext: StackContext(),
+      options: Options(
+        isQaMode: false,
+        isCacheDisabled: false,
+        trackingCallBackWithUser: (_) {},
+      ),
+    );
+
+GBContext _gbContext({
+  StickyBucketService? stickyBucketService,
+  List<String>? stickyBucketIdentifierAttributes,
+  Map<String, GBFeature>? features,
+}) =>
+    GBContext(
+      apiKey: 'key',
+      hostURL: 'https://example.com',
+      attributes: {'id': 'user-1'},
+      enabled: true,
+      forcedVariation: {},
+      qaMode: false,
+      trackingCallBack: (_) {},
+      stickyBucketService: stickyBucketService,
+      stickyBucketIdentifierAttributes: stickyBucketIdentifierAttributes,
+      features: features ?? {},
+    );
+
+void main() {
+  // -------------------------------------------------------------------------
+  // GBFilter — toJson
+  // -------------------------------------------------------------------------
+  group('GBFilter', () {
+    test('toJson / fromJson round-trips all fields', () {
+      final filter = GBFilter(
+        seed: 'my-seed',
+        ranges: [
+          [0.0, 0.5]
+        ],
+        attribute: 'id',
+        hashVersion: 2,
+      );
+      final json = filter.toJson();
+      final restored = GBFilter.fromJson(json);
+
+      expect(restored.seed, 'my-seed');
+      expect(restored.attribute, 'id');
+      expect(restored.hashVersion, 2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // FeatureURLBuilder — SERVER_SENT_REMOTE_FEATURE_EVAL branch
+  // -------------------------------------------------------------------------
+  group('FeatureURLBuilder', () {
+    test('builds URL for SERVER_SENT_REMOTE_FEATURE_EVAL strategy', () {
+      final url = FeatureURLBuilder.buildUrl(
+        'https://example.com/',
+        'my-key',
+        featureRefreshStrategy:
+            FeatureRefreshStrategy.SERVER_SENT_REMOTE_FEATURE_EVAL,
+      );
+      expect(url, contains('api/eval'));
+      expect(url, endsWith('my-key'));
+    });
+
+    test('builds URL for SERVER_SENT_EVENTS strategy', () {
+      final url = FeatureURLBuilder.buildUrl(
+        'https://example.com/',
+        'my-key',
+        featureRefreshStrategy: FeatureRefreshStrategy.SERVER_SENT_EVENTS,
+      );
+      expect(url, contains('sub'));
+      expect(url, endsWith('my-key'));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GBUtils.getHashAttribute — attributeOverrides paths
+  // -------------------------------------------------------------------------
+  group('GBUtils.getHashAttribute', () {
+    test('returns value from attributeOverrides when present', () {
+      final result = GBUtils.getHashAttribute(
+        attr: 'id',
+        attributes: {'id': 'original'},
+        attributeOverrides: {'id': 'overridden'},
+      );
+      expect(result[1], 'overridden');
+    });
+
+    test('falls back to attributeOverrides when primary attr is empty', () {
+      final result = GBUtils.getHashAttribute(
+        attr: 'id',
+        fallback: 'device',
+        attributes: {'id': '', 'device': 'dev-1'},
+        attributeOverrides: {'device': 'dev-override'},
+      );
+      expect(result[0], 'device');
+      expect(result[1], 'dev-override');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GBUtils.deriveStickyBucketIdentifierAttributes
+  // -------------------------------------------------------------------------
+  group('GBUtils.deriveStickyBucketIdentifierAttributes', () {
+    test('returns empty list when features have no rules with variations', () {
+      final context = _gbContext(
+        features: {'flag': GBFeature(defaultValue: true)},
+      );
+      final result = GBUtils.deriveStickyBucketIdentifierAttributes(
+        context: context,
+        data: null,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('collects hashAttribute from rules with variations', () {
+      final rule = GBFeatureRule(
+        hashAttribute: 'id',
+        variations: ['control', 'treatment'],
+      );
+      final context = _gbContext(
+        features: {
+          'flag': GBFeature(rules: [rule]),
+        },
+      );
+      final result = GBUtils.deriveStickyBucketIdentifierAttributes(
+        context: context,
+        data: null,
+      );
+      expect(result, contains('id'));
+    });
+
+    test('collects fallbackAttribute when present', () {
+      final rule = GBFeatureRule(
+        hashAttribute: 'id',
+        fallbackAttribute: 'device',
+        variations: ['a', 'b'],
+      );
+      final context = _gbContext(
+        features: {
+          'flag': GBFeature(rules: [rule]),
+        },
+      );
+      final result = GBUtils.deriveStickyBucketIdentifierAttributes(
+        context: context,
+        data: null,
+      );
+      expect(result, contains('id'));
+      expect(result, contains('device'));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GBUtils.getStickyBucketAttributes
+  // -------------------------------------------------------------------------
+  group('GBUtils.getStickyBucketAttributes', () {
+    test('returns empty map when stickyBucketIdentifierAttributes is empty', () {
+      final context = _gbContext(stickyBucketIdentifierAttributes: []);
+      final result = GBUtils.getStickyBucketAttributes(context, null, {});
+      expect(result, isEmpty);
+    });
+
+    test('returns attributes map for given identifier attributes', () {
+      final context = _gbContext(
+        stickyBucketIdentifierAttributes: ['id'],
+      );
+      final result = GBUtils.getStickyBucketAttributes(
+        context,
+        null,
+        {'id': 'user-42'},
+      );
+      expect(result.containsKey('id'), isTrue);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GBUtils.refreshStickyBuckets
+  // -------------------------------------------------------------------------
+  group('GBUtils.refreshStickyBuckets', () {
+    test('does nothing when stickyBucketService is null', () async {
+      final context = _gbContext();
+      await expectLater(
+        GBUtils.refreshStickyBuckets(context, null, {}),
+        completes,
+      );
+    });
+
+    test('populates stickyBucketAssignmentDocs when service is set', () async {
+      final svc = LocalStorageStickyBucketService(
+        localStorage: _InMemoryCache(),
+      );
+      final context = _gbContext(
+        stickyBucketService: svc,
+        stickyBucketIdentifierAttributes: ['id'],
+      );
+      await GBUtils.refreshStickyBuckets(context, null, {'id': 'user-1'});
+      // No crash — docs map is assigned (may be empty since nothing was saved)
+      expect(context.stickyBucketAssignmentDocs, isNotNull);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GBUtils.getStickyBucketVariation — invalid variation key path
+  // -------------------------------------------------------------------------
+  group('GBUtils.getStickyBucketVariation', () {
+    test('returns variation -1 when assignment key exists but meta has no match',
+        () {
+      const expKey = 'my-exp';
+      const bucketVersion = 0;
+      final assignmentKey =
+          GBUtils.getStickyBucketExperimentKey(expKey, bucketVersion);
+
+      final doc = StickyAssignmentsDocument(
+        attributeName: 'id',
+        attributeValue: 'user-1',
+        assignments: {assignmentKey: 'nonexistent-variation'},
+      );
+
+      final context = _evalContext(
+        attributes: {'id': 'user-1'},
+        docs: {'id||user-1': doc},
+      );
+
+      final result = GBUtils.getStickyBucketVariation(
+        context: context,
+        experimentKey: expKey,
+        experimentBucketVersion: bucketVersion,
+        minExperimentBucketVersion: 0,
+        meta: [
+          GBVariationMeta(key: 'control'),
+          GBVariationMeta(key: 'treatment'),
+        ],
+        expHashAttribute: 'id',
+        expFallBackAttribute: null,
+      );
+
+      expect(result.variation, -1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // RoundToExtension — tested via num (not double) to avoid DoubleExt conflict
+  // -------------------------------------------------------------------------
+  group('RoundToExtension', () {
+    test('roundTo rounds to given fraction digits', () {
+      // Use int literal (extends num) so RoundToExtension takes priority over DoubleExt
+      final n = 3 as num;
+      expect(n.roundTo(numFractionDigits: 4), 3.0);
+    });
+
+    test('roundTo with 0 fraction digits (default) returns whole number', () {
+      final n = 5 as num;
+      expect(n.roundTo(numFractionDigits: 0), 5.0);
+    });
+
+    test('roundTo clamps negative fractionDigits to 0', () {
+      final n = 7 as num;
+      expect(() => n.roundTo(numFractionDigits: -1), returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
  - Added unit tests across all major modules: network layer, feature evaluation, crypto, caching, sticky bucketing,
  SSE pipeline, and model classes
  - Coverage increased from ~60% to 96.4% (1493/1548 lines)
  - No production code was changed
  
  ## New test files
  - `gb_sdk_subscriptions_test.dart` — subscription system
  - `gb_sdk_attributes_test.dart` — attribute/variation management
  - `gb_sdk_remote_eval_test.dart` — remote eval flow and isOn()
  - `gb_sdk_saved_groups_test.dart` — saved groups callbacks
  - `sse_layer_test.dart` — SSE parsing pipeline
  - `features_view_model_extra_test.dart` — FeatureViewModel additional coverage
  - `dio_client_test.dart` — DioClient network layer
  - `sticky_bucket_service_test.dart` — LocalStorageStickyBucketService
  - `experiment_test.dart` — GBExperiment
  - `features_model_test.dart` — GBFeatureRule and GBFeatureResult
  - `model_data_classes_test.dart` — GBExperimentResult, GBVariationMeta, GBTrack, RemoteEvalModel, GBParentCondition
  - `utility_classes_test.dart` — GBFilter, FeatureURLBuilder, GBUtils, RoundToExtension
  - `crypto_utils_test.dart` — Crypto, DecryptionUtils
  - `caching_manager_extra_test.dart` — CachingManager additional coverage
  - `lru_cache_and_feature_evaluator_test.dart` — LruEtagCache and FeatureEvaluator