### PR TITLE
fix: make publish dry-run non-blocking in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,7 +44,8 @@ jobs:
         
       - name: Check publish warnings
         run: dart pub publish --dry-run
-        
+        continue-on-error: true
+
       - name: Release Please
         id: release
         uses: googleapis/release-please-action@v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,19 +32,24 @@ jobs:
           
       - name: Install dependencies
         run: flutter pub get
-        
-      - name: Run build_runner
-        run: dart run build_runner build --delete-conflicting-outputs
-        
-      - name: Analyze code
-        run: dart analyze --fatal-infos
-        
-      - name: Run tests
-        run: flutter test
-        
+
+      # Run dry-run BEFORE build_runner regenerates .g.dart files. Otherwise
+      # any drift between the committed generated files and the freshly built
+      # ones is reported as "checked-in file is modified in git" (exit 65),
+      # blocking the real Release Please step even though the package is
+      # otherwise valid. Running dry-run against the clean checkout keeps
+      # full publish validation active while avoiding the false positive.
       - name: Check publish warnings
         run: dart pub publish --dry-run
-        continue-on-error: true
+
+      - name: Run build_runner
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Analyze code
+        run: dart analyze --fatal-infos
+
+      - name: Run tests
+        run: flutter test
 
       - name: Release Please
         id: release


### PR DESCRIPTION
build_runner regenerates .g.dart files on CI which appear as modified files to dart pub publish --dry-run, causing exit code 61 and blocking the release-please action from creating the tag.