### PR TITLE
test: add cross-SDK fnv1a32 hash vectors

### DIFF
--- a/test/common_test/fnv1a32_hash_test.dart
+++ b/test/common_test/fnv1a32_hash_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/src/Utils/gb_utils.dart';
+
+// Vectors from growthbook/growthbook packages/sdk-js/src/util.ts hashFnv32a().
+// Regenerate: node -e "console.log(hashFnv32a('...'))"
+void main() {
+  final fnv = FNV();
+
+  group('fnv1a32 – ASCII inputs', () {
+    const vectors = <String, int>{
+      '': 2166136261,
+      'a': 3826002220,
+      'b': 3876335077,
+      'abc': 440920331,
+      'hello': 1335831723,
+      'test123': 950984763,
+      'foo': 2851307223,
+      'bar': 1991736602,
+      'z': 4278997933,   // bit-31 overflow
+      'zz': 1466432373,
+      'zzz': 2813343901,
+    };
+
+    vectors.forEach((input, expected) {
+      test('fnv1a32("$input") == $expected', () {
+        expect(fnv.fnv1a32(input), equals(expected));
+      });
+    });
+  });
+
+  group('fnv1a32 – Unicode / UTF-16 inputs', () {
+    // Verifies codeUnitAt() is not masked to 8 bits (old bug: & 0xFF).
+    const vectors = <String, int>{
+      'Ā': 84593183,    // U+0100 — first code unit > 255
+      'ā': 67815564,    // U+0101
+      'я': 3389371454,  // U+044F
+      'тест': 8839891,
+      '耀': 71490847,   // U+8000, high bit set
+      '￿': 2041487694,  // U+FFFF, max BMP
+    };
+
+    vectors.forEach((input, expected) {
+      test('fnv1a32("$input") == $expected', () {
+        expect(fnv.fnv1a32(input), equals(expected));
+      });
+    });
+  });
+
+  group('fnv1a32 – version 2 intermediate values', () {
+    // v2 applies fnv1a32 twice: fnv1a32(fnv1a32(seed+value).toString())
+    test('fnv1a32("seeda") == 717764279', () {
+      expect(fnv.fnv1a32('seeda'), equals(717764279));
+    });
+
+    test('fnv1a32("717764279") == 2503390505', () {
+      expect(fnv.fnv1a32('717764279'), equals(2503390505));
+    });
+
+    test('fnv1a32("fooab") == 514738336', () {
+      expect(fnv.fnv1a32('fooab'), equals(514738336));
+    });
+
+    test('fnv1a32("514738336") == 3887382575', () {
+      expect(fnv.fnv1a32('514738336'), equals(3887382575));
+    });
+  });
+}


### PR DESCRIPTION
Adds known input/output pairs for `fnv1a32`, validated against the JS SDK's `hashFnv32a()` reference. Acts as a regression guard for any
   future changes to the hash implementation.
   
  ## Coverage

  - ASCII inputs (`""`, `"a"`, `"hello"`, `"test123"`, bit-31 overflow case)
  - Unicode/UTF-16 inputs — verifies `codeUnitAt()` is not masked to 8 bits
  - v2 double-hash intermediate values
 
  ## Background

  The original `fnv1a32` JS-alignment fix landed in main independently via commit `200f1d7` ("accept full 16-bit integer val", Jan 20).
  The test vectors were never merged — they lived only in #158 (which had too many regressions from a stale base to merge cleanly).
  
  @madhuchavva explicitly requested these vectors in the #128 review. This PR extracts them as a small focused change against current
  main.
  
  ## Verification
  
  All 21 tests pass on current main (`origin/main`).